### PR TITLE
[#3] 모의고사 페이지 퍼블리싱

### DIFF
--- a/src/app/(main)/exam/page.tsx
+++ b/src/app/(main)/exam/page.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import WrongQuestionsSummaryBox from '@/components/exam/WrongAnswerSummaryCard';
+import SelectSubjectYearComboBox from '@/components/exam/SelectSubjectYearComboBox';
+
+const Exam = () => {
+  return (
+    <div>
+      <WrongQuestionsSummaryBox />
+      <SolveExamBox />
+    </div>
+  );
+};
+
+const SolveExamBox = () => {
+  return (
+    <div>
+      <div className="mt-8">
+        <div className="w-[85%] mx-auto font-black text-h4">모의고사 풀기</div>
+        <SelectSubjectYearComboBox />
+      </div>
+    </div>
+  );
+};
+
+export default Exam;

--- a/src/app/(main)/exam/wrong/page.tsx
+++ b/src/app/(main)/exam/wrong/page.tsx
@@ -1,0 +1,5 @@
+const Wrong = () => {
+  return <div>틀린문제페이지</div>;
+};
+
+export default Wrong;

--- a/src/components/exam/SelectSubjectYearComboBox.tsx
+++ b/src/components/exam/SelectSubjectYearComboBox.tsx
@@ -1,25 +1,43 @@
+'use client';
+import React, { useState } from 'react';
 import SubjectSessionCard from './SubjectSessionCard';
+import { SubjectInfo } from '@/types/global';
+import SubjectData from '@/utils/dummyData'; // Import dummy data
 
-// 해당 과목의 연도를 필터링 하기 위한 모듈
-const SelectSubjectYearComboBox = () => {
+interface SelectSubjectYearComboBoxProps {
+  subjectData: SubjectInfo[] | undefined;
+}
+
+const SelectSubjectYearComboBox: React.FC<SelectSubjectYearComboBoxProps> = ({ subjectData }) => {
+  const [selectedSubject, setSelectedSubject] = useState<SubjectInfo | null>(null);
+
+  const handleSubjectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedYear = parseInt(event.target.value, 10);
+    const newSelectedSubject = SubjectData.find((subject) => subject.year === selectedYear) || null;
+    setSelectedSubject(newSelectedSubject);
+  };
+
+  // Get unique years from SubjectData
+  const uniqueYears = Array.from(new Set(SubjectData.map((subject) => subject.year)));
+
   return (
     <div className="mt-2">
       <select
         id="subject"
         name="subject"
+        value={selectedSubject?.year || ''}
+        onChange={handleSubjectChange}
         className="mx-auto mt-1 text-h4 font-bold block w-[90%] p-3 bg-gray0 rounded-xl shadow-sm focus:outline-none focus:ring focus:border-blue-300 sm:text-sm">
-        <option>2022년 기출 모의고사</option>
-        <option>2023년 기출 모의고사</option>
-        <option>2024년 기출 모의고사</option>
+        {uniqueYears.map((year, index) => (
+          <option key={index} value={year}>
+            {year}년 기출 모의고사
+          </option>
+        ))}
       </select>
       <div className="w-[95%] mx-auto">
         <div className="mt-4 flex flex-wrap">
-          <SubjectSessionCard />
-          <SubjectSessionCard />
-          <SubjectSessionCard />
-          <SubjectSessionCard />
-          <SubjectSessionCard />
-          <SubjectSessionCard />
+          {/* SubjectSessionCard 컴포넌트에는 필요한 Props를 전달해주세요 */}
+          <SubjectSessionCard selectedSubject={selectedSubject} subjectData={subjectData} />
         </div>
       </div>
     </div>

--- a/src/components/exam/SelectSubjectYearComboBox.tsx
+++ b/src/components/exam/SelectSubjectYearComboBox.tsx
@@ -1,0 +1,29 @@
+import SubjectSessionCard from './SubjectSessionCard';
+
+// 해당 과목의 연도를 필터링 하기 위한 모듈
+const SelectSubjectYearComboBox = () => {
+  return (
+    <div className="mt-2">
+      <select
+        id="subject"
+        name="subject"
+        className="mx-auto mt-1 text-h4 font-bold block w-[90%] p-3 bg-gray0 rounded-xl shadow-sm focus:outline-none focus:ring focus:border-blue-300 sm:text-sm">
+        <option>2022년 기출 모의고사</option>
+        <option>2023년 기출 모의고사</option>
+        <option>2024년 기출 모의고사</option>
+      </select>
+      <div className="w-[95%] mx-auto">
+        <div className="mt-4 flex flex-wrap">
+          <SubjectSessionCard />
+          <SubjectSessionCard />
+          <SubjectSessionCard />
+          <SubjectSessionCard />
+          <SubjectSessionCard />
+          <SubjectSessionCard />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SelectSubjectYearComboBox;

--- a/src/components/exam/SessionModal.tsx
+++ b/src/components/exam/SessionModal.tsx
@@ -1,0 +1,51 @@
+import SubjectGradeCard from './SubjectGradeCard';
+
+// 회차별 모달
+const SessionModal = ({ closeModal }) => {
+  // 예시 데이터
+  const subjects = ['컴퓨터 일반', '스프레드시트', '데이터베이스'];
+  const grades = ['4', '6', '2'];
+
+  return (
+    <div>
+      <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-30">
+        <div className="w-[80%]">
+          <button onClick={closeModal} className="w-full flex justify-end text-white text-h6 px-2 my-2">
+            닫기 X
+          </button>
+          <div className="bg-white rounded-3xl">
+            <div className="w-[90%] mx-auto">
+              <h2 className="flex justify-between text-h4 font-bold p-4">
+                <button>{`<`}</button>
+                <div>n회차</div>
+                <button>{`>`}</button>
+              </h2>
+              <div className="border-t border-gray1"></div>
+              <div className="flex justify-between my-3">
+                <div>
+                  <div className="font-bold text-h6">최근 점수</div>
+                  <div className="flex items-end">
+                    <div className="font-bold text-h1">30점</div>
+                    <div className="mt-1 text-gray3">/50점</div>
+                  </div>
+                </div>
+                <button className="h-1/2 bg-gray0 rounded-3xl text-h6 font-bold p-2">성적 리포트 ➚</button>
+              </div>
+              <div className="text-h6 font-bold mt-5">과목별 맞춘 문제 수</div>
+              <div className="flex my-2">
+                {subjects.map((subject, index) => (
+                  <SubjectGradeCard key={index} subject={subject} grade={grades[index]} />
+                ))}
+              </div>
+              <div className="flex justify-center">
+                <button className="w-full bg-black text-white rounded-3xl text-h5 p-4 my-4">시험 보기</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SessionModal;

--- a/src/components/exam/SubjectGradeCard.tsx
+++ b/src/components/exam/SubjectGradeCard.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const SubjectGradeCard = ({ subject, grade }) => {
+  return (
+    <div className="w-full border border-gray2">
+      <div className="text-lg text-center text-h6 py-2">{subject}</div>
+      <div className="flex justify-center border-t border-gray2 py-2">
+        <div className="flex items-end">
+          <div className="font-bold text-h3">{grade}개</div>
+          <div className="text-gray3 text-h7">/50개</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SubjectGradeCard;

--- a/src/components/exam/SubjectSessionCard.tsx
+++ b/src/components/exam/SubjectSessionCard.tsx
@@ -1,9 +1,13 @@
-'use client';
-
 import React, { useState } from 'react';
 import SessionModal from './SessionModal';
+import { SubjectInfo } from '@/types/global';
 
-const SubjectSessionCard = () => {
+interface SubjectSessionCardProps {
+  selectedSubject: SubjectInfo | null;
+  subjectData: SubjectInfo[] | undefined;
+}
+
+const SubjectSessionCard: React.FC<SubjectSessionCardProps> = ({ selectedSubject, subjectData }) => {
   const [modalIsOpen, setModalIsOpen] = useState(false);
 
   const openModal = () => {
@@ -14,23 +18,34 @@ const SubjectSessionCard = () => {
     setModalIsOpen(false);
   };
 
-  return (
-    <div className="w-1/2 mb-4">
-      <div className="w-[90%] mx-auto p-3 border border-gray2 rounded-3xl">
-        <div className="text-black font-bold text-center">{`1회차`}</div>
-        <div className="border-t border-gray1 my-2"></div>
-        <div className="text-black text-center text-h7">최근 점수</div>
-        <ul className="flex text-center justify-center">
-          <div className="font-bold text-h2">{`10점`}</div>
-          <div className="mt-1 text-gray3">/50점</div>
-        </ul>
-        <button onClick={() => openModal()} className="w-full bg-gray1 rounded-3xl py-3 mt-4 text-h6 font-bold">
-          시험 보기
-        </button>
+  // 해당 연도의 세션 정보를 가져오기
+  const sessions = selectedSubject?.sessions;
 
-        {modalIsOpen && <SessionModal closeModal={closeModal} />}
-      </div>
-    </div>
+  if (!sessions) {
+    return <div>해당 연도의 데이터가 없습니다.</div>;
+  }
+
+  return (
+    <>
+      {sessions.map((session, index) => (
+        <div key={index} className="w-1/2 mb-4">
+          <div className="w-[90%] mx-auto p-3 border border-gray2 rounded-3xl">
+            <div className="text-black font-bold text-center">{`${session.sessionNumber}회차`}</div>
+            <div className="border-t border-gray1 my-2"></div>
+            <div className="text-black text-center text-h7">최근 점수</div>
+            <ul className="flex text-center justify-center">
+              <li className="font-bold text-h2">{`${session.totalcorrect}점`}</li>
+              <div className="mt-1 text-gray3">/50점</div>
+            </ul>
+            <button onClick={() => openModal()} className="w-full bg-gray1 rounded-3xl py-3 mt-4 text-h6 font-bold">
+              시험 보기
+            </button>
+
+            {modalIsOpen && <SessionModal closeModal={closeModal} />}
+          </div>
+        </div>
+      ))}
+    </>
   );
 };
 

--- a/src/components/exam/SubjectSessionCard.tsx
+++ b/src/components/exam/SubjectSessionCard.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React, { useState } from 'react';
+import SessionModal from './SessionModal';
+
+const SubjectSessionCard = () => {
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+
+  const openModal = () => {
+    setModalIsOpen(true);
+  };
+
+  const closeModal = () => {
+    setModalIsOpen(false);
+  };
+
+  return (
+    <div className="w-1/2 mb-4">
+      <div className="w-[90%] mx-auto p-3 border border-gray2 rounded-3xl">
+        <div className="text-black font-bold text-center">{`1회차`}</div>
+        <div className="border-t border-gray1 my-2"></div>
+        <div className="text-black text-center text-h7">최근 점수</div>
+        <ul className="flex text-center justify-center">
+          <div className="font-bold text-h2">{`10점`}</div>
+          <div className="mt-1 text-gray3">/50점</div>
+        </ul>
+        <button onClick={() => openModal()} className="w-full bg-gray1 rounded-3xl py-3 mt-4 text-h6 font-bold">
+          시험 보기
+        </button>
+
+        {modalIsOpen && <SessionModal closeModal={closeModal} />}
+      </div>
+    </div>
+  );
+};
+
+export default SubjectSessionCard;

--- a/src/components/exam/WrongAnswerSummaryCard.tsx
+++ b/src/components/exam/WrongAnswerSummaryCard.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+
+const WrongQuestionsSummaryBox = () => {
+  return (
+    <div className="mx-5 mt-4 w-[90%] p-3 rounded-3xl bg-blue">
+      <div className="px-2">
+        <div className="text-white font-bold text-left text-h4 my-1">지금까지 틀린문제만 모아봤어요.</div>
+        <Link href="/exam/wrong">
+          <div className="inline-block rounded-3xl bg-white text-blue text-h6 my-1 px-3 py-1">틀린 문제 풀기 ➚</div>
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default WrongQuestionsSummaryBox;

--- a/src/components/exam/WrongAnswerSummaryCard.tsx
+++ b/src/components/exam/WrongAnswerSummaryCard.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 const WrongQuestionsSummaryBox = () => {
   return (
-    <div className="mx-5 mt-4 w-[90%] p-3 rounded-3xl bg-blue">
+    <div className="mx-auto mt-4 w-[90%] p-3 rounded-3xl bg-blue">
       <div className="px-2">
         <div className="text-white font-bold text-left text-h4 my-1">지금까지 틀린문제만 모아봤어요.</div>
         <Link href="/exam/wrong">

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -4,3 +4,12 @@ export interface MenuList {
   name: string;
   path: string;
 }
+
+export interface SubjectInfo {
+  year: number;
+  session: number;
+  subsubject: string[];
+  subsubjectgrade: number[];
+  totalcorrect: number;
+  totalproblem: number;
+}

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -7,9 +7,11 @@ export interface MenuList {
 
 export interface SubjectInfo {
   year: number;
-  session: number;
-  subsubject: string[];
-  subsubjectgrade: number[];
+  sessions: Session[];
+}
+
+export interface Session {
+  sessionNumber: number;
   totalcorrect: number;
   totalproblem: number;
 }

--- a/src/utils/dummyData.tsx
+++ b/src/utils/dummyData.tsx
@@ -1,39 +1,38 @@
 import { SubjectInfo } from '@/types/global';
 
-const SubjectData: SubjectInfo[] = [
+const subjectData: SubjectInfo[] = [
   {
     year: 2022,
-    session: 1,
-    subsubject: ['Math', 'Physics', 'Chemistry'],
-    subsubjectgrade: [80, 90, 85],
-    totalcorrect: 255,
-    totalproblem: 300,
-  },
-  {
-    year: 2022,
-    session: 2,
-    subsubject: ['Math', 'Physics', 'Chemistry'],
-    subsubjectgrade: [85, 88, 92],
-    totalcorrect: 265,
-    totalproblem: 300,
+    sessions: [
+      { sessionNumber: 1, totalcorrect: 10, totalproblem: 50 },
+      { sessionNumber: 2, totalcorrect: 20, totalproblem: 50 },
+      { sessionNumber: 3, totalcorrect: 30, totalproblem: 50 },
+    ],
   },
   {
     year: 2023,
-    session: 1,
-    subsubject: ['Math', 'Physics', 'Chemistry'],
-    subsubjectgrade: [78, 92, 87],
-    totalcorrect: 257,
-    totalproblem: 300,
+    sessions: [
+      { sessionNumber: 1, totalcorrect: 15, totalproblem: 50 },
+      { sessionNumber: 2, totalcorrect: 25, totalproblem: 50 },
+      { sessionNumber: 3, totalcorrect: 35, totalproblem: 50 },
+    ],
   },
   {
-    year: 2023,
-    session: 2,
-    subsubject: ['Math', 'Physics', 'Chemistry'],
-    subsubjectgrade: [90, 85, 88],
-    totalcorrect: 263,
-    totalproblem: 300,
+    year: 2024,
+    sessions: [
+      { sessionNumber: 1, totalcorrect: 18, totalproblem: 50 },
+      { sessionNumber: 2, totalcorrect: 28, totalproblem: 50 },
+      { sessionNumber: 3, totalcorrect: 38, totalproblem: 50 },
+    ],
   },
-  // Add more data as needed
+  {
+    year: 2025,
+    sessions: [
+      { sessionNumber: 1, totalcorrect: 12, totalproblem: 50 },
+      { sessionNumber: 2, totalcorrect: 22, totalproblem: 50 },
+      { sessionNumber: 3, totalcorrect: 32, totalproblem: 50 },
+    ],
+  },
 ];
 
-export default SubjectData;
+export default subjectData;

--- a/src/utils/dummyData.tsx
+++ b/src/utils/dummyData.tsx
@@ -1,0 +1,39 @@
+import { SubjectInfo } from '@/types/global';
+
+const SubjectData: SubjectInfo[] = [
+  {
+    year: 2022,
+    session: 1,
+    subsubject: ['Math', 'Physics', 'Chemistry'],
+    subsubjectgrade: [80, 90, 85],
+    totalcorrect: 255,
+    totalproblem: 300,
+  },
+  {
+    year: 2022,
+    session: 2,
+    subsubject: ['Math', 'Physics', 'Chemistry'],
+    subsubjectgrade: [85, 88, 92],
+    totalcorrect: 265,
+    totalproblem: 300,
+  },
+  {
+    year: 2023,
+    session: 1,
+    subsubject: ['Math', 'Physics', 'Chemistry'],
+    subsubjectgrade: [78, 92, 87],
+    totalcorrect: 257,
+    totalproblem: 300,
+  },
+  {
+    year: 2023,
+    session: 2,
+    subsubject: ['Math', 'Physics', 'Chemistry'],
+    subsubjectgrade: [90, 85, 88],
+    totalcorrect: 263,
+    totalproblem: 300,
+  },
+  // Add more data as needed
+];
+
+export default SubjectData;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,11 +7,36 @@ const config: Config = {
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
-    extend: {
-      backgroundImage: {
-        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
-        'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
-      },
+    colors: {
+      // Brand colors
+      primary: '#3B3DFF',
+      second: '#6283FD',
+
+      // Particular colors
+      point: '#FF6A3B',
+
+      // Achromatic colors
+      black: '#191919',
+      gray4: '#727375',
+      gray3: '#9E9FA1',
+      gray2: '#CBCCCE',
+      gray1: '#E4E5E7',
+      gray0: '#F4F5F7',
+      white: '#FFFFFF',
+      blue: '#6283FD',
+
+      // 그 외 추가 컬러
+      // ...
+    },
+    fontSize: {
+      //폰트 사이즈
+      h1: '24px', // Head 1
+      h2: '20px', // Title 1
+      h3: '18px', // Title 2, 3
+      h4: '16px', // Title 4, 5, SubTitle 1, Body1
+      h5: '15px',
+      h6: '14px', // SubTitle 2, Body2, Button
+      h7: '12px',
     },
   },
   plugins: [],


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->
## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->
**WrongQuestionsSummaryBox.tsx**
- 틀린문제모음으로 이동하는 박스에 대한 퍼블리싱을 진행했습니다.
- 틀린문제모음 버튼을 누르면 /exam/wrong 라우터로 이동 

**SelectSubjectYearComboBox**
- 해당 과목의 연도를 필터링하는 콤보박스에 대한 디자인을 퍼블리싱 하였습니다.
아직 데이터의 구조 `year` 등에 대한 정보가 없으므로, 기능 구현은 하지 않았습니다.

**SubjectSessionCard**
- 연도별로 필터링된 과목에 대한 회차별 시험 성적으로 나타내기 위한 카드의 디자인을 퍼블리싱 하였습니다.

**SessionModal**
- SubjectSessionCard 에서 해당 회차 시험보기 버튼을 눌렀을때 뜨는 모달에 대한 퍼블리싱을 하였습니다.
## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->
- 데이터 명세가 아직 되지 않아, 기능 부분을 배제하고 퍼블리싱만 진행하였는데 임의로 데이터 구조를 만들어서 기능 구현을
하는게 맞는지 모르겠습니다.

- 추가로 기능을 구현할때 상태관리에 대한 고려를 어느정도 하고 진행을 해야하는지에 대한 의문점이 있습니다.

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
