### PR TITLE
[#9] 모의고사 메인페이지 기능 구현

### DIFF
--- a/src/app/(main)/exam/page.tsx
+++ b/src/app/(main)/exam/page.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import WrongQuestionsSummaryBox from '@/components/exam/WrongAnswerSummaryCard';
+import SelectSubjectYearComboBox from '@/components/exam/SelectSubjectYearComboBox';
+
+const Exam = () => {
+  return (
+    <div>
+      <WrongQuestionsSummaryBox />
+      <SolveExamBox />
+    </div>
+  );
+};
+
+const SolveExamBox = () => {
+  return (
+    <div>
+      <div className="mt-8">
+        <div className="w-[85%] mx-auto font-black text-h4">모의고사 풀기</div>
+        <SelectSubjectYearComboBox />
+      </div>
+    </div>
+  );
+};
+
+export default Exam;

--- a/src/app/(main)/exam/page.tsx
+++ b/src/app/(main)/exam/page.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
-import WrongQuestionsSummaryBox from '@/components/exam/WrongAnswerSummaryCard';
+import React from 'react';
+
 import SelectSubjectYearComboBox from '@/components/exam/SelectSubjectYearComboBox';
+import WrongQuestionsSummaryBox from '@/components/exam/WrongAnswerSummaryCard';
 
 const Exam = () => {
   return (

--- a/src/app/(main)/exam/wrong/page.tsx
+++ b/src/app/(main)/exam/wrong/page.tsx
@@ -1,0 +1,5 @@
+const Wrong = () => {
+  return <div>틀린문제페이지</div>;
+};
+
+export default Wrong;

--- a/src/components/exam/SelectSubjectYearComboBox.tsx
+++ b/src/components/exam/SelectSubjectYearComboBox.tsx
@@ -1,14 +1,13 @@
 'use client';
 import React, { useState } from 'react';
-import SubjectSessionCard from './SubjectSessionCard';
+
 import { SubjectInfo } from '@/types/global';
 import SubjectData from '@/utils/dummyData'; // Import dummy data
 
-interface SelectSubjectYearComboBoxProps {
-  subjectData: SubjectInfo[] | undefined;
-}
+import SubjectSessionCard from './SubjectSessionCard';
 
-const SelectSubjectYearComboBox: React.FC<SelectSubjectYearComboBoxProps> = ({ subjectData }) => {
+// 과목에 Year를 필터링 해주는 모듈
+const SelectSubjectYearComboBox = ({}) => {
   const [selectedSubject, setSelectedSubject] = useState<SubjectInfo | null>(null);
 
   const handleSubjectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -36,8 +35,7 @@ const SelectSubjectYearComboBox: React.FC<SelectSubjectYearComboBoxProps> = ({ s
       </select>
       <div className="w-[95%] mx-auto">
         <div className="mt-4 flex flex-wrap">
-          {/* SubjectSessionCard 컴포넌트에는 필요한 Props를 전달해주세요 */}
-          <SubjectSessionCard selectedSubject={selectedSubject} subjectData={subjectData} />
+          <SubjectSessionCard selectedSubject={selectedSubject} />
         </div>
       </div>
     </div>

--- a/src/components/exam/SelectSubjectYearComboBox.tsx
+++ b/src/components/exam/SelectSubjectYearComboBox.tsx
@@ -1,0 +1,47 @@
+'use client';
+import React, { useState } from 'react';
+import SubjectSessionCard from './SubjectSessionCard';
+import { SubjectInfo } from '@/types/global';
+import SubjectData from '@/utils/dummyData'; // Import dummy data
+
+interface SelectSubjectYearComboBoxProps {
+  subjectData: SubjectInfo[] | undefined;
+}
+
+const SelectSubjectYearComboBox: React.FC<SelectSubjectYearComboBoxProps> = ({ subjectData }) => {
+  const [selectedSubject, setSelectedSubject] = useState<SubjectInfo | null>(null);
+
+  const handleSubjectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedYear = parseInt(event.target.value, 10);
+    const newSelectedSubject = SubjectData.find((subject) => subject.year === selectedYear) || null;
+    setSelectedSubject(newSelectedSubject);
+  };
+
+  // Get unique years from SubjectData
+  const uniqueYears = Array.from(new Set(SubjectData.map((subject) => subject.year)));
+
+  return (
+    <div className="mt-2">
+      <select
+        id="subject"
+        name="subject"
+        value={selectedSubject?.year || ''}
+        onChange={handleSubjectChange}
+        className="mx-auto mt-1 text-h4 font-bold block w-[90%] p-3 bg-gray0 rounded-xl shadow-sm focus:outline-none focus:ring focus:border-blue-300 sm:text-sm">
+        {uniqueYears.map((year, index) => (
+          <option key={index} value={year}>
+            {year}년 기출 모의고사
+          </option>
+        ))}
+      </select>
+      <div className="w-[95%] mx-auto">
+        <div className="mt-4 flex flex-wrap">
+          {/* SubjectSessionCard 컴포넌트에는 필요한 Props를 전달해주세요 */}
+          <SubjectSessionCard selectedSubject={selectedSubject} subjectData={subjectData} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SelectSubjectYearComboBox;

--- a/src/components/exam/SelectSubjectYearComboBox.tsx
+++ b/src/components/exam/SelectSubjectYearComboBox.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { SubjectInfo } from '@/types/global';
 import SubjectData from '@/utils/dummyData'; // Import dummy data
@@ -10,13 +10,18 @@ import SubjectSessionCard from './SubjectSessionCard';
 const SelectSubjectYearComboBox = ({}) => {
   const [selectedSubject, setSelectedSubject] = useState<SubjectInfo | null>(null);
 
+  useEffect(() => {
+    const defaultYear = SubjectData[0]?.year || null;
+    const defaultSubject = SubjectData.find((subject) => subject.year === defaultYear) || null;
+    setSelectedSubject(defaultSubject);
+  }, []); // 빈 배열을 넣어 처음 렌더링 시에만 실행되도록 설정
+
   const handleSubjectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedYear = parseInt(event.target.value, 10);
     const newSelectedSubject = SubjectData.find((subject) => subject.year === selectedYear) || null;
     setSelectedSubject(newSelectedSubject);
   };
-
-  // Get unique years from SubjectData
+  // 유니크한 연도만 추출
   const uniqueYears = Array.from(new Set(SubjectData.map((subject) => subject.year)));
 
   return (

--- a/src/components/exam/SessionModal.tsx
+++ b/src/components/exam/SessionModal.tsx
@@ -1,7 +1,7 @@
 import SubjectGradeCard from './SubjectGradeCard';
 
 // 회차별 모달
-const SessionModal = ({ closeModal }) => {
+const SessionModal: React.FC<{ closeModal: () => void }> = ({ closeModal }) => {
   // 예시 데이터
   const subjects = ['컴퓨터 일반', '스프레드시트', '데이터베이스'];
   const grades = ['4', '6', '2'];

--- a/src/components/exam/SessionModal.tsx
+++ b/src/components/exam/SessionModal.tsx
@@ -1,10 +1,19 @@
+import React from 'react';
+
+import { Session } from '@/types/global';
+
 import SubjectGradeCard from './SubjectGradeCard';
 
-// 회차별 모달
-const SessionModal: React.FC<{ closeModal: () => void }> = ({ closeModal }) => {
-  // 예시 데이터
-  const subjects = ['컴퓨터 일반', '스프레드시트', '데이터베이스'];
-  const grades = ['4', '6', '2'];
+interface SessionModalProps {
+  closeModal: () => void;
+  selectedSession: Session; // 선택된 회차에 대한 데이터
+}
+
+const SessionModal: React.FC<SessionModalProps> = ({ closeModal, selectedSession }) => {
+  // 세부 과목에 대한 데이터를 더미 데이터 대신에 props로 받은 데이터 사용
+  const subjects = selectedSession.subjects;
+
+  console.log(selectedSession);
 
   return (
     <div>
@@ -17,7 +26,7 @@ const SessionModal: React.FC<{ closeModal: () => void }> = ({ closeModal }) => {
             <div className="w-[90%] mx-auto">
               <h2 className="flex justify-between text-h4 font-bold p-4">
                 <button>{'<'}</button>
-                <div>n회차</div>
+                <div>{`${selectedSession.sessionNumber}회차`}</div>
                 <button>{'>'}</button>
               </h2>
               <div className="border-t border-gray1"></div>
@@ -25,8 +34,8 @@ const SessionModal: React.FC<{ closeModal: () => void }> = ({ closeModal }) => {
                 <div>
                   <div className="font-bold text-h6">최근 점수</div>
                   <div className="flex items-end">
-                    <div className="font-bold text-h1">30점</div>
-                    <div className="mt-1 text-gray3">/50점</div>
+                    <div className="font-bold text-h1">{`${selectedSession.totalCorrect}점`}</div>
+                    <div className="mt-1 text-gray3">/{`${selectedSession.totalProblem}점`}</div>
                   </div>
                 </div>
                 <button className="h-1/2 bg-gray0 rounded-3xl text-h6 font-bold p-2">성적 리포트 ➚</button>
@@ -34,7 +43,12 @@ const SessionModal: React.FC<{ closeModal: () => void }> = ({ closeModal }) => {
               <div className="text-h6 font-bold mt-5">과목별 맞춘 문제 수</div>
               <div className="flex my-2">
                 {subjects.map((subject, index) => (
-                  <SubjectGradeCard key={index} subject={subject} grade={grades[index]} />
+                  <SubjectGradeCard
+                    key={index}
+                    name={subject.name}
+                    correctAnswer={subject.correctAnswer}
+                    totalCorrect={subject.totalProblems}
+                  />
                 ))}
               </div>
               <div className="flex justify-center">

--- a/src/components/exam/SessionModal.tsx
+++ b/src/components/exam/SessionModal.tsx
@@ -13,8 +13,6 @@ const SessionModal: React.FC<SessionModalProps> = ({ closeModal, selectedSession
   // 세부 과목에 대한 데이터를 더미 데이터 대신에 props로 받은 데이터 사용
   const subjects = selectedSession.subjects;
 
-  console.log(selectedSession);
-
   return (
     <div>
       <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-30">

--- a/src/components/exam/SessionModal.tsx
+++ b/src/components/exam/SessionModal.tsx
@@ -16,9 +16,9 @@ const SessionModal = ({ closeModal }) => {
           <div className="bg-white rounded-3xl">
             <div className="w-[90%] mx-auto">
               <h2 className="flex justify-between text-h4 font-bold p-4">
-                <button>{`<`}</button>
+                <button>{'<'}</button>
                 <div>n회차</div>
-                <button>{`>`}</button>
+                <button>{'>'}</button>
               </h2>
               <div className="border-t border-gray1"></div>
               <div className="flex justify-between my-3">

--- a/src/components/exam/SessionModal.tsx
+++ b/src/components/exam/SessionModal.tsx
@@ -1,0 +1,51 @@
+import SubjectGradeCard from './SubjectGradeCard';
+
+// 회차별 모달
+const SessionModal = ({ closeModal }) => {
+  // 예시 데이터
+  const subjects = ['컴퓨터 일반', '스프레드시트', '데이터베이스'];
+  const grades = ['4', '6', '2'];
+
+  return (
+    <div>
+      <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-30">
+        <div className="w-[80%]">
+          <button onClick={closeModal} className="w-full flex justify-end text-white text-h6 px-2 my-2">
+            닫기 X
+          </button>
+          <div className="bg-white rounded-3xl">
+            <div className="w-[90%] mx-auto">
+              <h2 className="flex justify-between text-h4 font-bold p-4">
+                <button>{`<`}</button>
+                <div>n회차</div>
+                <button>{`>`}</button>
+              </h2>
+              <div className="border-t border-gray1"></div>
+              <div className="flex justify-between my-3">
+                <div>
+                  <div className="font-bold text-h6">최근 점수</div>
+                  <div className="flex items-end">
+                    <div className="font-bold text-h1">30점</div>
+                    <div className="mt-1 text-gray3">/50점</div>
+                  </div>
+                </div>
+                <button className="h-1/2 bg-gray0 rounded-3xl text-h6 font-bold p-2">성적 리포트 ➚</button>
+              </div>
+              <div className="text-h6 font-bold mt-5">과목별 맞춘 문제 수</div>
+              <div className="flex my-2">
+                {subjects.map((subject, index) => (
+                  <SubjectGradeCard key={index} subject={subject} grade={grades[index]} />
+                ))}
+              </div>
+              <div className="flex justify-center">
+                <button className="w-full bg-black text-white rounded-3xl text-h5 p-4 my-4">시험 보기</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SessionModal;

--- a/src/components/exam/SubjectGradeCard.tsx
+++ b/src/components/exam/SubjectGradeCard.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const SubjectGradeCard = ({ subject, grade }) => {
+  return (
+    <div className="w-full border border-gray2">
+      <div className="text-lg text-center text-h6 py-2">{subject}</div>
+      <div className="flex justify-center border-t border-gray2 py-2">
+        <div className="flex items-end">
+          <div className="font-bold text-h3">{grade}개</div>
+          <div className="text-gray3 text-h7">/50개</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SubjectGradeCard;

--- a/src/components/exam/SubjectGradeCard.tsx
+++ b/src/components/exam/SubjectGradeCard.tsx
@@ -1,13 +1,21 @@
 import React from 'react';
 
-const SubjectGradeCard = ({ subject, grade }) => {
+import { SpecificSubject } from '@/types/global';
+
+interface SubjectGradeCardProps {
+  name: SpecificSubject['name'];
+  correctAnswer: SpecificSubject['correctAnswer'];
+  totalCorrect: SpecificSubject['totalProblems'];
+}
+
+const SubjectGradeCard: React.FC<SubjectGradeCardProps> = ({ name, correctAnswer, totalCorrect }) => {
   return (
     <div className="w-full border border-gray2">
-      <div className="text-lg text-center text-h6 py-2">{subject}</div>
+      <div className="text-lg text-center text-h6 py-2">{name}</div>
       <div className="flex justify-center border-t border-gray2 py-2">
         <div className="flex items-end">
-          <div className="font-bold text-h3">{grade}개</div>
-          <div className="text-gray3 text-h7">/50개</div>
+          <div className="font-bold text-h3">{correctAnswer}개</div>
+          <div className="text-gray3 text-h7">/{totalCorrect}개</div>
         </div>
       </div>
     </div>

--- a/src/components/exam/SubjectSessionCard.tsx
+++ b/src/components/exam/SubjectSessionCard.tsx
@@ -1,20 +1,24 @@
 import React, { useState } from 'react';
+
+import { Session, SubjectInfo } from '@/types/global';
+
 import SessionModal from './SessionModal';
-import { SubjectInfo } from '@/types/global';
 
 interface SubjectSessionCardProps {
   selectedSubject: SubjectInfo | null;
-  subjectData: SubjectInfo[] | undefined;
 }
 
-const SubjectSessionCard: React.FC<SubjectSessionCardProps> = ({ selectedSubject, subjectData }) => {
+const SubjectSessionCard: React.FC<SubjectSessionCardProps> = ({ selectedSubject }) => {
+  const [selectedSession, setSelectedSession] = useState<Session | null>(null);
   const [modalIsOpen, setModalIsOpen] = useState(false);
 
-  const openModal = () => {
+  const openModal = (session: Session) => {
+    setSelectedSession(session);
     setModalIsOpen(true);
   };
 
   const closeModal = () => {
+    setSelectedSession(null);
     setModalIsOpen(false);
   };
 
@@ -34,17 +38,18 @@ const SubjectSessionCard: React.FC<SubjectSessionCardProps> = ({ selectedSubject
             <div className="border-t border-gray1 my-2"></div>
             <div className="text-black text-center text-h7">최근 점수</div>
             <ul className="flex text-center justify-center">
-              <li className="font-bold text-h2">{`${session.totalcorrect}점`}</li>
-              <div className="mt-1 text-gray3">/50점</div>
+              <li className="font-bold text-h2">{`${session.totalCorrect}점`}</li>
+              <div className="mt-1 text-gray3">{`/${session.totalProblem}점`}</div>
             </ul>
-            <button onClick={() => openModal()} className="w-full bg-gray1 rounded-3xl py-3 mt-4 text-h6 font-bold">
+            <button
+              onClick={() => openModal(session)}
+              className="w-full bg-gray1 rounded-3xl py-3 mt-4 text-h6 font-bold">
               시험 보기
             </button>
-
-            {modalIsOpen && <SessionModal closeModal={closeModal} />}
           </div>
         </div>
       ))}
+      {modalIsOpen && selectedSession && <SessionModal closeModal={closeModal} selectedSession={selectedSession} />}
     </>
   );
 };

--- a/src/components/exam/SubjectSessionCard.tsx
+++ b/src/components/exam/SubjectSessionCard.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import SessionModal from './SessionModal';
+import { SubjectInfo } from '@/types/global';
+
+interface SubjectSessionCardProps {
+  selectedSubject: SubjectInfo | null;
+  subjectData: SubjectInfo[] | undefined;
+}
+
+const SubjectSessionCard: React.FC<SubjectSessionCardProps> = ({ selectedSubject, subjectData }) => {
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+
+  const openModal = () => {
+    setModalIsOpen(true);
+  };
+
+  const closeModal = () => {
+    setModalIsOpen(false);
+  };
+
+  // 해당 연도의 세션 정보를 가져오기
+  const sessions = selectedSubject?.sessions;
+
+  if (!sessions) {
+    return <div>해당 연도의 데이터가 없습니다.</div>;
+  }
+
+  return (
+    <>
+      {sessions.map((session, index) => (
+        <div key={index} className="w-1/2 mb-4">
+          <div className="w-[90%] mx-auto p-3 border border-gray2 rounded-3xl">
+            <div className="text-black font-bold text-center">{`${session.sessionNumber}회차`}</div>
+            <div className="border-t border-gray1 my-2"></div>
+            <div className="text-black text-center text-h7">최근 점수</div>
+            <ul className="flex text-center justify-center">
+              <li className="font-bold text-h2">{`${session.totalcorrect}점`}</li>
+              <div className="mt-1 text-gray3">/50점</div>
+            </ul>
+            <button onClick={() => openModal()} className="w-full bg-gray1 rounded-3xl py-3 mt-4 text-h6 font-bold">
+              시험 보기
+            </button>
+
+            {modalIsOpen && <SessionModal closeModal={closeModal} />}
+          </div>
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default SubjectSessionCard;

--- a/src/components/exam/TimerModal.tsx
+++ b/src/components/exam/TimerModal.tsx
@@ -1,9 +1,15 @@
-const SessionModal = () => {
+interface SessionModalProps {
+  closeModal: () => void;
+}
+
+const TimerModal: React.FC<SessionModalProps> = ({ closeModal }) => {
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-30">
-      <div>asd</div>
+      <div className="w-[80%]">
+        <button className="w-full flex justify-end text-white text-h6 px-2 my-2">닫기 X</button>
+      </div>
     </div>
   );
 };
 
-export default SessionModal;
+export default TimerModal;

--- a/src/components/exam/TimerModal.tsx
+++ b/src/components/exam/TimerModal.tsx
@@ -1,0 +1,9 @@
+const SessionModal = () => {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-30">
+      <div>asd</div>
+    </div>
+  );
+};
+
+export default SessionModal;

--- a/src/components/exam/WrongAnswerSummaryCard.tsx
+++ b/src/components/exam/WrongAnswerSummaryCard.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+
+const WrongQuestionsSummaryBox = () => {
+  return (
+    <div className="mx-auto mt-4 w-[90%] p-3 rounded-3xl bg-blue">
+      <div className="px-2">
+        <div className="text-white font-bold text-left text-h4 my-1">지금까지 틀린문제만 모아봤어요.</div>
+        <Link href="/exam/wrong">
+          <div className="inline-block rounded-3xl bg-white text-blue text-h6 my-1 px-3 py-1">틀린 문제 풀기 ➚</div>
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default WrongQuestionsSummaryBox;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -7,6 +7,15 @@ export interface MenuList {
   path: string;
 }
 
+export interface SubjectInfo {
+  year: number;
+  sessions: Session[];
+}
+
+export interface Session {
+  sessionNumber: number;
+  totalcorrect: number;
+  totalproblem: number;
 // 온보딩 관심 자격증 리스트
 export const LicenseInfo: Array<License> = [];
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -7,15 +7,22 @@ export interface MenuList {
   path: string;
 }
 
+// 과목에 대한 정보
 export interface SubjectInfo {
   year: number;
   sessions: Session[];
 }
 
+// 과목 - 회차에 대한 정보
 export interface Session {
+  // 회차 정보 ex) 2023년 - 1회차
   sessionNumber: number;
+  // 총 맞춘 정답 개수
   totalcorrect: number;
+  // 총 문제 개수
   totalproblem: number;
+}
+
 // 온보딩 관심 자격증 리스트
 export const LicenseInfo: Array<License> = [];
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -9,7 +9,9 @@ export interface MenuList {
 
 // 과목에 대한 정보
 export interface SubjectInfo {
+  // 과목의 연도 정보
   year: number;
+  // 회차 리스트
   sessions: Session[];
 }
 
@@ -18,9 +20,17 @@ export interface Session {
   // 회차 정보 ex) 2023년 - 1회차
   sessionNumber: number;
   // 총 맞춘 정답 개수
-  totalcorrect: number;
+  totalCorrect: number;
   // 총 문제 개수
-  totalproblem: number;
+  totalProblem: number;
+  // 과목내 세부과목에 대한 정보를 담고있음
+  subjects: SpecificSubject[];
+}
+
+export interface SpecificSubject {
+  name: string;
+  correctAnswer: number;
+  totalProblems: number;
 }
 
 // 온보딩 관심 자격증 리스트

--- a/src/utils/dummyData.tsx
+++ b/src/utils/dummyData.tsx
@@ -11,6 +11,8 @@ const subjectData: SubjectInfo[] = [
         subjects: [
           { name: '과목1', correctAnswer: 5, totalProblems: 10 },
           { name: '과목2', correctAnswer: 3, totalProblems: 10 },
+          { name: '과목2', correctAnswer: 3, totalProblems: 10 },
+          { name: '과목2', correctAnswer: 3, totalProblems: 10 },
         ],
       },
       {

--- a/src/utils/dummyData.tsx
+++ b/src/utils/dummyData.tsx
@@ -1,38 +1,103 @@
-import { SubjectInfo } from '@/types/global';
+import { Session, SpecificSubject, SubjectInfo } from '@/types/global';
 
 const subjectData: SubjectInfo[] = [
   {
     year: 2022,
     sessions: [
-      { sessionNumber: 1, totalcorrect: 10, totalproblem: 50 },
-      { sessionNumber: 2, totalcorrect: 20, totalproblem: 50 },
-      { sessionNumber: 3, totalcorrect: 30, totalproblem: 50 },
+      {
+        sessionNumber: 1,
+        totalCorrect: 10,
+        totalProblem: 50,
+        subjects: [
+          { name: '과목1', correctAnswer: 5, totalProblems: 10 },
+          { name: '과목2', correctAnswer: 3, totalProblems: 10 },
+        ],
+      },
+      {
+        sessionNumber: 2,
+        totalCorrect: 20,
+        totalProblem: 50,
+        subjects: [
+          { name: '과목1', correctAnswer: 8, totalProblems: 10 },
+          { name: '과목2', correctAnswer: 6, totalProblems: 10 },
+        ],
+      },
+      {
+        sessionNumber: 3,
+        totalCorrect: 30,
+        totalProblem: 50,
+        subjects: [
+          { name: '과목1', correctAnswer: 10, totalProblems: 10 },
+          { name: '과목2', correctAnswer: 9, totalProblems: 10 },
+        ],
+      },
     ],
   },
   {
     year: 2023,
     sessions: [
-      { sessionNumber: 1, totalcorrect: 15, totalproblem: 50 },
-      { sessionNumber: 2, totalcorrect: 25, totalproblem: 50 },
-      { sessionNumber: 3, totalcorrect: 35, totalproblem: 50 },
+      {
+        sessionNumber: 1,
+        totalCorrect: 12,
+        totalProblem: 50,
+        subjects: [
+          { name: '과목1', correctAnswer: 6, totalProblems: 10 },
+          { name: '과목2', correctAnswer: 4, totalProblems: 10 },
+        ],
+      },
+      {
+        sessionNumber: 2,
+        totalCorrect: 22,
+        totalProblem: 50,
+        subjects: [
+          { name: '과목1', correctAnswer: 9, totalProblems: 10 },
+          { name: '과목2', correctAnswer: 7, totalProblems: 10 },
+        ],
+      },
+      {
+        sessionNumber: 3,
+        totalCorrect: 32,
+        totalProblem: 50,
+        subjects: [
+          { name: '과목1', correctAnswer: 9, totalProblems: 10 },
+          { name: '과목2', correctAnswer: 10, totalProblems: 10 },
+        ],
+      },
     ],
   },
   {
     year: 2024,
     sessions: [
-      { sessionNumber: 1, totalcorrect: 18, totalproblem: 50 },
-      { sessionNumber: 2, totalcorrect: 28, totalproblem: 50 },
-      { sessionNumber: 3, totalcorrect: 38, totalproblem: 50 },
+      {
+        sessionNumber: 1,
+        totalCorrect: 15,
+        totalProblem: 50,
+        subjects: [
+          { name: '과목1', correctAnswer: 7, totalProblems: 10 },
+          { name: '과목2', correctAnswer: 5, totalProblems: 10 },
+        ],
+      },
+      {
+        sessionNumber: 2,
+        totalCorrect: 25,
+        totalProblem: 50,
+        subjects: [
+          { name: '과목1', correctAnswer: 10, totalProblems: 10 },
+          { name: '과목2', correctAnswer: 8, totalProblems: 10 },
+        ],
+      },
+      {
+        sessionNumber: 3,
+        totalCorrect: 35,
+        totalProblem: 50,
+        subjects: [
+          { name: '과목1', correctAnswer: 13, totalProblems: 10 },
+          { name: '과목2', correctAnswer: 12, totalProblems: 10 },
+        ],
+      },
     ],
   },
-  {
-    year: 2025,
-    sessions: [
-      { sessionNumber: 1, totalcorrect: 12, totalproblem: 50 },
-      { sessionNumber: 2, totalcorrect: 22, totalproblem: 50 },
-      { sessionNumber: 3, totalcorrect: 32, totalproblem: 50 },
-    ],
-  },
+  // 다른 연도에 대한 데이터도 필요에 따라 추가
 ];
 
 export default subjectData;

--- a/src/utils/dummyData.tsx
+++ b/src/utils/dummyData.tsx
@@ -1,0 +1,38 @@
+import { SubjectInfo } from '@/types/global';
+
+const subjectData: SubjectInfo[] = [
+  {
+    year: 2022,
+    sessions: [
+      { sessionNumber: 1, totalcorrect: 10, totalproblem: 50 },
+      { sessionNumber: 2, totalcorrect: 20, totalproblem: 50 },
+      { sessionNumber: 3, totalcorrect: 30, totalproblem: 50 },
+    ],
+  },
+  {
+    year: 2023,
+    sessions: [
+      { sessionNumber: 1, totalcorrect: 15, totalproblem: 50 },
+      { sessionNumber: 2, totalcorrect: 25, totalproblem: 50 },
+      { sessionNumber: 3, totalcorrect: 35, totalproblem: 50 },
+    ],
+  },
+  {
+    year: 2024,
+    sessions: [
+      { sessionNumber: 1, totalcorrect: 18, totalproblem: 50 },
+      { sessionNumber: 2, totalcorrect: 28, totalproblem: 50 },
+      { sessionNumber: 3, totalcorrect: 38, totalproblem: 50 },
+    ],
+  },
+  {
+    year: 2025,
+    sessions: [
+      { sessionNumber: 1, totalcorrect: 12, totalproblem: 50 },
+      { sessionNumber: 2, totalcorrect: 22, totalproblem: 50 },
+      { sessionNumber: 3, totalcorrect: 32, totalproblem: 50 },
+    ],
+  },
+];
+
+export default subjectData;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -23,6 +23,7 @@ const config: Config = {
       gray1: '#E4E5E7',
       gray0: '#F4F5F7',
       white: '#FFFFFF',
+      blue: '#6283FD',
 
       // 그 외 추가 컬러
       // ...
@@ -35,6 +36,7 @@ const config: Config = {
       h4: '16px', // Title 4, 5, SubTitle 1, Body1
       h5: '15px',
       h6: '14px', // SubTitle 2, Body2, Button
+      h7: '12px',
     },
   },
   plugins: [],


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

- 모의고사 메인페이지에서 사용할 데이터 구조를 간략하게 완성
- 모의고사의 연도별 데이터 (Year) 필터링 하는 컴포넌트 기능 구현
- 연도별로 필터링된 데이터의 회차 (Session) 별로 구분하여 출력하는 List 컴포넌트 구현
- 해당 Session별 카드를 클릭하면 나타나는 모듈창 구현 완료
<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

## ✅ PR Point

데이터가 최상위 컴포넌트를 타고 하위 컴포넌트로 수직적으로 흘러가는 구조인데 유지 보수 관점에서 문제가 없을지 궁금합니다.
<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

