### PR TITLE
[#26] 모의고사 결과 페이지 응시 횟수 구분 기능 구현

### DIFF
--- a/src/app/(main)/exam/page.tsx
+++ b/src/app/(main)/exam/page.tsx
@@ -1,14 +1,18 @@
 'use client';
 import React from 'react';
 
+import Header from '@/components/common/Header';
+import NavBar from '@/components/common/NavBar';
 import SelectSubjectYearComboBox from '@/components/exam/SelectSubjectYearComboBox';
 import WrongQuestionsSummaryBox from '@/components/exam/WrongAnswerSummaryCard';
 
 const Exam = () => {
   return (
     <div>
+      <Header />
       <WrongQuestionsSummaryBox />
       <SolveExamBox />
+      <NavBar />
     </div>
   );
 };

--- a/src/app/(main)/exam/report/page.tsx
+++ b/src/app/(main)/exam/report/page.tsx
@@ -7,12 +7,13 @@ import ReportCard from '@/components/exam/ReportCard';
 import RoundFilter from '@/components/exam/RoundFilter';
 import StayTimeGraph from '@/components/exam/StayTimeGraph';
 import SubjectGradeCard from '@/components/exam/SubjectGradeCard';
-import { Session } from '@/types/global'; // Session 타입의 경로에 따라 수정
-import { selectedSessionState } from '@/utils/recoilState';
+import { Round, Session } from '@/types/global'; // Session 타입의 경로에 따라 수정
+import { selectedRoundState, selectedSessionState } from '@/utils/recoilState';
 
 const Report: React.FC = () => {
   const [selectedSession, setSelectedSession] = useRecoilState<Session | null>(selectedSessionState);
-  const subjects = selectedSession?.subjects;
+  const [selectedRound, setSelectedRound] = useRecoilState<Round | null>(selectedRoundState);
+  const subjects = selectedRound?.subjects;
 
   return (
     <div>
@@ -36,8 +37,8 @@ const Report: React.FC = () => {
           <div className="flex space-x-2 my-4">
             <ReportCard
               title="최근 점수"
-              main={selectedSession?.totalCorrect + '점'}
-              total={selectedSession?.totalProblem + '점'}
+              main={selectedRound?.totalCorrect + '점'}
+              total={selectedRound?.totalProblem + '점'}
             />
             <ReportCard title="걸린시간" main="48:00" total="60:00(분)" />
           </div>

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -4,10 +4,10 @@ import { useParams, useRouter } from 'next/navigation';
 import * as React from 'react';
 import { useState } from 'react';
 import { useRecoilState } from 'recoil';
+import css from 'styled-jsx/css';
 
 import Button from '@/components/common/Button';
 import { layoutState } from '@/recoil/atom';
-import css from 'styled-jsx/css';
 
 export default function Home() {
   const router = useRouter();

--- a/src/components/exam/CorrectRateGraph.tsx
+++ b/src/components/exam/CorrectRateGraph.tsx
@@ -1,14 +1,15 @@
 import { useRecoilState } from 'recoil';
 
-import { Session } from '@/types/global';
-import { selectedSessionState } from '@/utils/recoilState';
+import { Round, Session } from '@/types/global';
+import { selectedRoundState, selectedSessionState } from '@/utils/recoilState';
 
 import Example from './SimpleChart';
 
 const CorrectRateGraph: React.FC = () => {
   const [selectedSession, setselectedSession] = useRecoilState<Session | null>(selectedSessionState);
+  const [selectedRound, setSelectedRound] = useRecoilState<Round | null>(selectedRoundState);
 
-  const subjects = selectedSession?.subjects;
+  const subjects = selectedRound?.subjects;
 
   const radarChartData = subjects?.map((subject) => {
     return {
@@ -18,11 +19,6 @@ const CorrectRateGraph: React.FC = () => {
       // 다른 필요한 필드가 있다면 추가
     };
   });
-
-  console.log(subjects);
-  if (subjects) {
-    console.log(radarChartData);
-  }
 
   return (
     <div>

--- a/src/components/exam/RoundFilter.tsx
+++ b/src/components/exam/RoundFilter.tsx
@@ -1,11 +1,35 @@
+import React, { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+
+import { Round, Session } from '@/types/global';
+import { selectedRoundState, selectedSessionState } from '@/utils/recoilState';
+
 const RoundFilter: React.FC = () => {
+  const [selectedSession, setSelectedSession] = useRecoilState<Session | null>(selectedSessionState);
+  const [selectedRound, setSelectedRound] = useRecoilState<Round | null>(selectedRoundState);
+
+  // session에서 roundNumber를 추출하여 중복 제거한 배열
+  const uniqueRoundNumbers = Array.from(new Set(selectedSession?.rounds.map((round) => round.roundNumber) || []));
+
+  const handleRoundChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedRoundNumber = parseInt(event.target.value, 10);
+    const selectedRound = selectedSession?.rounds.find((round) => round.roundNumber === selectedRoundNumber) || null;
+    setSelectedRound(selectedRound);
+  };
+
   return (
     <div className="mt-2">
       <select
         id="subject"
         name="subject"
+        value={selectedRound?.roundNumber || ''}
+        onChange={handleRoundChange}
         className="w-[100%] mx-auto mt-1 text-h4 font-bold block p-3 bg-white rounded-xl shadow-sm focus:outline-none focus:ring focus:border-blue-300 sm:text-sm">
-        <option>1회</option>
+        {uniqueRoundNumbers.map((round, index) => (
+          <option key={index} value={round}>
+            {round}회
+          </option>
+        ))}
       </select>
     </div>
   );

--- a/src/components/exam/SelectSubjectYearComboBox.tsx
+++ b/src/components/exam/SelectSubjectYearComboBox.tsx
@@ -7,7 +7,6 @@ import SubjectData from '@/utils/dummyData'; // Import dummy data
 import { selectedSubjectState } from '@/utils/recoilState';
 
 import SubjectSessionCard from './SubjectSessionCard';
-
 // 과목에 Year를 필터링 해주는 모듈
 const SelectSubjectYearComboBox = ({}) => {
   const [selectedSubject, setSelectedSubject] = useRecoilState<SubjectInfo | null>(selectedSubjectState);

--- a/src/components/exam/SelectSubjectYearComboBox.tsx
+++ b/src/components/exam/SelectSubjectYearComboBox.tsx
@@ -22,7 +22,7 @@ const SelectSubjectYearComboBox = ({}) => {
     const newSelectedSubject = SubjectData.find((subject) => subject.year === selectedYear) || null;
     setSelectedSubject(newSelectedSubject);
   };
-  // 유니크한 연도만 추출
+  // 유니크한 연도 추출
   const uniqueYears = Array.from(new Set(SubjectData.map((subject) => subject.year)));
 
   return (

--- a/src/components/exam/SessionModal.tsx
+++ b/src/components/exam/SessionModal.tsx
@@ -2,8 +2,8 @@ import Link from 'next/link';
 import React, { useState } from 'react';
 import { useRecoilState } from 'recoil';
 
-import { Session } from '@/types/global';
-import { selectedSessionState } from '@/utils/recoilState';
+import { Round, Session } from '@/types/global';
+import { selectedRoundState, selectedSessionState } from '@/utils/recoilState';
 
 import SubjectGradeCard from './SubjectGradeCard';
 
@@ -14,8 +14,9 @@ interface SessionModalProps {
 
 const SessionModal: React.FC<SessionModalProps> = ({ closeModal, openTimerModal }) => {
   const [selectedSession, setSelectedSession] = useRecoilState<Session | null>(selectedSessionState);
+  const [selectedRound, setSelectedRound] = useRecoilState<Round | null>(selectedRoundState);
   // 세부 과목에 대한 데이터를 더미 데이터 대신에 props로 받은 데이터 사용
-  const subjects = selectedSession?.subjects;
+  const subjects = selectedRound?.subjects;
 
   return (
     <div>
@@ -36,8 +37,8 @@ const SessionModal: React.FC<SessionModalProps> = ({ closeModal, openTimerModal 
                 <div>
                   <div className="font-bold text-h6">최근 점수</div>
                   <div className="flex items-end">
-                    <div className="font-bold text-h1">{`${selectedSession?.totalCorrect}점`}</div>
-                    <div className="text-gray3 text-h6 mb-1">/{`${selectedSession?.totalProblem}점`}</div>
+                    <div className="font-bold text-h1">{`${selectedRound?.totalCorrect}점`}</div>
+                    <div className="text-gray3 text-h6 mb-1">/{`${selectedRound?.totalProblem}점`}</div>
                   </div>
                 </div>
                 <Link href={'/exam/report'} className="h-1/2 bg-gray0 rounded-3xl text-h6 font-bold p-2">

--- a/src/components/exam/SimpleChart.tsx
+++ b/src/components/exam/SimpleChart.tsx
@@ -11,7 +11,7 @@ interface RadarChartExampleProps {
   data: RadarData[] | undefined;
 }
 
-// 정답률 그려주는 그래프
+// 정답률
 const RadarChartExample: React.FC<RadarChartExampleProps> = ({ data }) => {
   return (
     <ResponsiveContainer className="text-h7 text-start font-bold" width="100%" height="100%">

--- a/src/components/exam/StayTimeGraph.tsx
+++ b/src/components/exam/StayTimeGraph.tsx
@@ -1,14 +1,15 @@
 import { useRecoilState } from 'recoil';
 
-import { Session } from '@/types/global';
-import { selectedSessionState } from '@/utils/recoilState';
+import { Round, Session } from '@/types/global';
+import { selectedRoundState, selectedSessionState } from '@/utils/recoilState';
 
 import StickGraph from './StickGraph';
 
 // examreportpage에서 머문시간 그래프를 나타내는 컴포넌트
 const StayTimeGraph: React.FC = () => {
   const [selectedSession, setSelectedSession] = useRecoilState<Session | null>(selectedSessionState);
-  const subjects = selectedSession?.subjects;
+  const [selectedRound, setSelectedRound] = useRecoilState<Round | null>(selectedRoundState);
+  const subjects = selectedRound?.subjects;
 
   return (
     <div>
@@ -16,11 +17,11 @@ const StayTimeGraph: React.FC = () => {
         <div className="font-bold text-h3">머문시간 그래프</div>
         <div className="text-h5 p-2">
           <div>걸린 시간</div>
-          <div className="font-bold">{selectedSession?.totalTakenTime}m</div>
+          <div className="font-bold">{selectedRound?.totalTakenTime}m</div>
         </div>
         <div className="flex items-center space-x-2">
           <div className="w-[85%] border-t border-gray1"></div>
-          <div className="w-[15%] text-gray3 text-h5">{selectedSession?.totalAllowedTime}분</div>
+          <div className="w-[15%] text-gray3 text-h5">{selectedRound?.totalAllowedTime}분</div>
         </div>
         <div className="flex items-end space-x-2">
           <div className="w-[85%]">

--- a/src/components/exam/StickGraph.tsx
+++ b/src/components/exam/StickGraph.tsx
@@ -3,7 +3,7 @@ interface StickGraphProps {
   color: string;
 }
 
-// report 페이지에서 쓰이는 그래프 컴포넌트입니다
+// report 페이지에서 쓰이는 그래프 컴포넌트
 const StickGraph: React.FC<StickGraphProps> = ({ height, color }) => {
   return <div style={{ height: `${height}%` }} className={`w-[20%] mt-auto bg-${color} rounded-t-full`}></div>;
 };

--- a/src/components/exam/SubjectSessionCard.tsx
+++ b/src/components/exam/SubjectSessionCard.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { useRecoilState } from 'recoil';
 
-import { Session, SubjectInfo } from '@/types/global';
-import { selectedSessionState, selectedSubjectState } from '@/utils/recoilState';
+import { Round, Session, SubjectInfo } from '@/types/global';
+import { selectedRoundState, selectedSessionState, selectedSubjectState } from '@/utils/recoilState';
 
 import SessionModal from './SessionModal';
 import TimerModal from './TimerModal';
@@ -11,12 +11,14 @@ import TimerModal from './TimerModal';
 const SubjectSessionCard: React.FC = ({}) => {
   const [selectedSubject, setSelectedSubject] = useRecoilState<SubjectInfo | null>(selectedSubjectState);
   const [selectedSession, setSelectedSession] = useRecoilState<Session | null>(selectedSessionState);
+  const [selectedRound, setSelectedRound] = useRecoilState<Round | null>(selectedRoundState);
   const [sessionModalIsOpen, setSessionModalIsOpen] = useState(false);
   const [timerModalIsOpen, setTimerModalIsOpen] = useState(false);
 
   // 모달이 열릴때 세션 상태 설정
-  const openSessionModal = (session: Session | null) => {
+  const openSessionModal = (session: Session | null, round: Round) => {
     setSelectedSession(session);
+    setSelectedRound(round);
     setSessionModalIsOpen(true);
   };
 
@@ -32,12 +34,8 @@ const SubjectSessionCard: React.FC = ({}) => {
     setSelectedSession(null);
     setTimerModalIsOpen(false);
   };
-
   // 해당 연도의 세션 정보를 가져오기
   const sessions = selectedSubject?.sessions;
-
-  console.log(sessions);
-
   if (!sessions) {
     return <div>해당 연도의 데이터가 없습니다.</div>;
   }
@@ -45,25 +43,32 @@ const SubjectSessionCard: React.FC = ({}) => {
   // 여기서 selectedSession 에 대한 전역 상태가 결정됩니다.
   return (
     <>
-      {sessions.map((session, index) => (
-        <div key={index} className="w-1/2 mb-4">
-          <div className="w-[90%] mx-auto p-3 border border-gray2 rounded-3xl">
-            <div className="text-black font-bold text-center">{`${session.sessionNumber}회차`}</div>
-            <div className="border-t border-gray1 my-2"></div>
-            <div className="text-black text-center text-h7">최근 점수</div>
-            <ul className="flex text-center justify-center">
-              <li className="font-bold text-h2">{`${session.totalCorrect}점`}</li>
-              <div className="mt-1 text-gray3">{`/${session.totalProblem}점`}</div>
-            </ul>
-            <button
-              onClick={() => openSessionModal(session)}
-              className="w-full bg-gray1 rounded-3xl py-3 mt-4 text-h6 font-bold">
-              시험 보기
-            </button>
-          </div>
-        </div>
-      ))}
-      {/* 세션 모달에 대한 코드 */}
+      {sessions.map((session, index) => {
+        // 세션의 rounds 배열이 존재하는지 확인
+        if (session.rounds && session.rounds.length > 0) {
+          const lastRound = session.rounds[session.rounds.length - 1]; // 마지막 라운드에 접근
+          return (
+            <div key={index} className="w-1/2 mb-4">
+              <div className="w-[90%] mx-auto p-3 border border-gray2 rounded-3xl">
+                <div className="text-black font-bold text-center">{`${session.sessionNumber}회차`}</div>
+                <div className="border-t border-gray1 my-2"></div>
+                <div className="text-black text-center text-h7">최근 점수</div>
+                <ul className="flex text-center justify-center">
+                  <li className="font-bold text-h2">{`${lastRound.totalCorrect}점`}</li>
+                  <div className="mt-1 text-gray3">{`/${lastRound.totalProblem}점`}</div>
+                </ul>
+                <button
+                  onClick={() => openSessionModal(session, lastRound)}
+                  className="w-full bg-gray1 rounded-3xl py-3 mt-4 text-h6 font-bold">
+                  시험 보기
+                </button>
+              </div>
+            </div>
+          );
+        } else {
+          return null; // rounds 배열이 비어있으면 해당 세션을 렌더링하지 않음
+        }
+      })}
       {sessionModalIsOpen && selectedSession && (
         <SessionModal closeModal={closeSessionModal} openTimerModal={openTimerModal} />
       )}

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -21,6 +21,14 @@ export interface Session {
   sessionNumber: number;
   // 시험을 응시한적이 있는지 여부 변수
   isTaken: boolean;
+  // 유저의 응시횟수를 구분하는 변수
+  rounds: Round[];
+}
+
+// 유저의 응시횟수를 구분하기 위한 정보
+export interface Round {
+  // 회차 변수
+  roundNumber: number;
   // 총 맞춘 정답 개수
   totalCorrect: number;
   // 총 문제 개수
@@ -46,7 +54,6 @@ export interface SpecificSubject {
   // 과목에 머문 시간
   takenTime: number;
 }
-
 // 온보딩 관심 자격증 리스트
 export const LicenseInfo: Array<License> = [];
 

--- a/src/utils/dummyData.tsx
+++ b/src/utils/dummyData.tsx
@@ -1,4 +1,4 @@
-import { Session, SpecificSubject, SubjectInfo } from '@/types/global';
+import { SubjectInfo } from '@/types/global';
 
 const subjectData: SubjectInfo[] = [
   {
@@ -7,40 +7,73 @@ const subjectData: SubjectInfo[] = [
       {
         sessionNumber: 1,
         isTaken: true,
-        totalCorrect: 20,
-        totalProblem: 50,
-        totalTakenTime: '68',
-        totalAllowedTime: '90',
-        subjects: [
-          { name: '컴퓨터 일반', correctAnswer: 9, totalProblems: 10, averageTime: 20, takenTime: 30 },
-          { name: '스프레드 시트', correctAnswer: 8, totalProblems: 10, averageTime: 30, takenTime: 60 },
-          { name: '데이터 베이스', correctAnswer: 8, totalProblems: 10, averageTime: 30, takenTime: 90 },
+        rounds: [
+          {
+            roundNumber: 1,
+            totalCorrect: 20,
+            totalProblem: 50,
+            totalTakenTime: '68',
+            totalAllowedTime: '90',
+            subjects: [
+              { name: '컴퓨터 일반', correctAnswer: 9, totalProblems: 10, averageTime: 20, takenTime: 30 },
+              { name: '스프레드 시트', correctAnswer: 8, totalProblems: 10, averageTime: 30, takenTime: 60 },
+              { name: '데이터 베이스', correctAnswer: 8, totalProblems: 10, averageTime: 30, takenTime: 90 },
+            ],
+          },
+          {
+            roundNumber: 2,
+            totalCorrect: 10,
+            totalProblem: 50,
+            totalTakenTime: '28',
+            totalAllowedTime: '50',
+            subjects: [
+              { name: '컴퓨터 일반', correctAnswer: 5, totalProblems: 10, averageTime: 20, takenTime: 10 },
+              { name: '스프레드 시트', correctAnswer: 4, totalProblems: 10, averageTime: 30, takenTime: 40 },
+              { name: '데이터 베이스', correctAnswer: 4, totalProblems: 10, averageTime: 30, takenTime: 70 },
+            ],
+          },
+          {
+            roundNumber: 3,
+            totalCorrect: 10,
+            totalProblem: 50,
+            totalTakenTime: '28',
+            totalAllowedTime: '50',
+            subjects: [
+              { name: '컴퓨터 일반', correctAnswer: 5, totalProblems: 10, averageTime: 20, takenTime: 10 },
+              { name: '스프레드 시트', correctAnswer: 4, totalProblems: 10, averageTime: 30, takenTime: 40 },
+              { name: '데이터 베이스', correctAnswer: 4, totalProblems: 10, averageTime: 30, takenTime: 70 },
+            ],
+          },
         ],
       },
       {
         sessionNumber: 2,
         isTaken: true,
-        totalCorrect: 20,
-        totalProblem: 50,
-        totalTakenTime: '48',
-        totalAllowedTime: '90',
-        subjects: [
-          { name: '컴퓨터 일반', correctAnswer: 5, totalProblems: 10, averageTime: 20, takenTime: 30 },
-          { name: '스프레드 시트', correctAnswer: 3, totalProblems: 10, averageTime: 30, takenTime: 60 },
-          { name: '데이터 베이스', correctAnswer: 3, totalProblems: 10, averageTime: 30, takenTime: 90 },
-        ],
-      },
-      {
-        sessionNumber: 3,
-        isTaken: false,
-        totalCorrect: 20,
-        totalProblem: 50,
-        totalTakenTime: '58',
-        totalAllowedTime: '90',
-        subjects: [
-          { name: '컴퓨터 일반', correctAnswer: 5, totalProblems: 10, averageTime: 20, takenTime: 30 },
-          { name: '스프레드 시트', correctAnswer: 3, totalProblems: 10, averageTime: 30, takenTime: 60 },
-          { name: '데이터 베이스', correctAnswer: 3, totalProblems: 10, averageTime: 30, takenTime: 90 },
+        rounds: [
+          {
+            roundNumber: 1,
+            totalCorrect: 20,
+            totalProblem: 50,
+            totalTakenTime: '68',
+            totalAllowedTime: '90',
+            subjects: [
+              { name: '컴퓨터 일반', correctAnswer: 9, totalProblems: 10, averageTime: 20, takenTime: 30 },
+              { name: '스프레드 시트', correctAnswer: 8, totalProblems: 10, averageTime: 30, takenTime: 60 },
+              { name: '데이터 베이스', correctAnswer: 8, totalProblems: 10, averageTime: 30, takenTime: 90 },
+            ],
+          },
+          {
+            roundNumber: 2,
+            totalCorrect: 10,
+            totalProblem: 50,
+            totalTakenTime: '68',
+            totalAllowedTime: '90',
+            subjects: [
+              { name: '컴퓨터 일반', correctAnswer: 9, totalProblems: 10, averageTime: 20, takenTime: 30 },
+              { name: '스프레드 시트', correctAnswer: 8, totalProblems: 10, averageTime: 30, takenTime: 60 },
+              { name: '데이터 베이스', correctAnswer: 8, totalProblems: 10, averageTime: 30, takenTime: 90 },
+            ],
+          },
         ],
       },
     ],
@@ -51,40 +84,61 @@ const subjectData: SubjectInfo[] = [
       {
         sessionNumber: 1,
         isTaken: true,
-        totalCorrect: 10,
-        totalProblem: 50,
-        totalTakenTime: '48',
-        totalAllowedTime: '90',
-        subjects: [
-          { name: '컴퓨터 일반', correctAnswer: 5, totalProblems: 10, averageTime: 20, takenTime: 30 },
-          { name: '스프레드 시트', correctAnswer: 3, totalProblems: 10, averageTime: 30, takenTime: 60 },
-          { name: '데이터 베이스', correctAnswer: 3, totalProblems: 10, averageTime: 30, takenTime: 90 },
+        rounds: [
+          {
+            roundNumber: 1,
+            totalCorrect: 20,
+            totalProblem: 50,
+            totalTakenTime: '68',
+            totalAllowedTime: '90',
+            subjects: [
+              { name: '컴퓨터 일반', correctAnswer: 9, totalProblems: 10, averageTime: 20, takenTime: 30 },
+              { name: '스프레드 시트', correctAnswer: 8, totalProblems: 10, averageTime: 30, takenTime: 60 },
+              { name: '데이터 베이스', correctAnswer: 8, totalProblems: 10, averageTime: 30, takenTime: 90 },
+            ],
+          },
+          {
+            roundNumber: 2,
+            totalCorrect: 20,
+            totalProblem: 50,
+            totalTakenTime: '68',
+            totalAllowedTime: '90',
+            subjects: [
+              { name: '컴퓨터 일반', correctAnswer: 9, totalProblems: 10, averageTime: 20, takenTime: 30 },
+              { name: '스프레드 시트', correctAnswer: 8, totalProblems: 10, averageTime: 30, takenTime: 60 },
+              { name: '데이터 베이스', correctAnswer: 8, totalProblems: 10, averageTime: 30, takenTime: 90 },
+            ],
+          },
         ],
       },
       {
         sessionNumber: 2,
         isTaken: true,
-        totalCorrect: 10,
-        totalProblem: 50,
-        totalTakenTime: '48',
-        totalAllowedTime: '90',
-        subjects: [
-          { name: '컴퓨터 일반', correctAnswer: 5, totalProblems: 10, averageTime: 20, takenTime: 30 },
-          { name: '스프레드 시트', correctAnswer: 3, totalProblems: 10, averageTime: 30, takenTime: 60 },
-          { name: '데이터 베이스', correctAnswer: 3, totalProblems: 10, averageTime: 30, takenTime: 90 },
-        ],
-      },
-      {
-        sessionNumber: 3,
-        isTaken: false,
-        totalCorrect: 10,
-        totalProblem: 50,
-        totalTakenTime: '48',
-        totalAllowedTime: '90',
-        subjects: [
-          { name: '컴퓨터 일반', correctAnswer: 5, totalProblems: 10, averageTime: 20, takenTime: 30 },
-          { name: '스프레드 시트', correctAnswer: 3, totalProblems: 10, averageTime: 30, takenTime: 60 },
-          { name: '데이터 베이스', correctAnswer: 3, totalProblems: 10, averageTime: 30, takenTime: 90 },
+        rounds: [
+          {
+            roundNumber: 1,
+            totalCorrect: 20,
+            totalProblem: 50,
+            totalTakenTime: '68',
+            totalAllowedTime: '90',
+            subjects: [
+              { name: '컴퓨터 일반', correctAnswer: 9, totalProblems: 10, averageTime: 20, takenTime: 30 },
+              { name: '스프레드 시트', correctAnswer: 8, totalProblems: 10, averageTime: 30, takenTime: 60 },
+              { name: '데이터 베이스', correctAnswer: 8, totalProblems: 10, averageTime: 30, takenTime: 90 },
+            ],
+          },
+          {
+            roundNumber: 2,
+            totalCorrect: 20,
+            totalProblem: 50,
+            totalTakenTime: '68',
+            totalAllowedTime: '90',
+            subjects: [
+              { name: '컴퓨터 일반', correctAnswer: 9, totalProblems: 10, averageTime: 20, takenTime: 30 },
+              { name: '스프레드 시트', correctAnswer: 8, totalProblems: 10, averageTime: 30, takenTime: 60 },
+              { name: '데이터 베이스', correctAnswer: 8, totalProblems: 10, averageTime: 30, takenTime: 90 },
+            ],
+          },
         ],
       },
     ],

--- a/src/utils/recoilState.tsx
+++ b/src/utils/recoilState.tsx
@@ -1,6 +1,6 @@
 import { atom } from 'recoil';
 
-import { Session, SubjectInfo } from '@/types/global';
+import { Round, Session, SubjectInfo } from '@/types/global';
 
 export const selectedSubjectState = atom<SubjectInfo | null>({
   key: 'selectedSubjectState',
@@ -10,5 +10,11 @@ export const selectedSubjectState = atom<SubjectInfo | null>({
 // 선택된 회차에 대한 상태
 export const selectedSessionState = atom<Session | null>({
   key: 'selectedSessionState',
+  default: null,
+});
+
+// 유저의 응시 횟수에 대한 상태
+export const selectedRoundState = atom<Round | null>({
+  key: 'selectedRoundState',
   default: null,
 });


### PR DESCRIPTION
성적리포트페이지 응시횟수구분 기능 구현
Closes #26 

<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

모의고사 report페이지에서 유저의 응시횟수 구분하는 selectbox를 추가하여 응시횟수별 state 변경 기능 구현하기

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
