### PR TITLE
[#30] 목표 설정 페이지 api 연동

### DIFF
--- a/src/app/(main)/home/exam-info/page.tsx
+++ b/src/app/(main)/home/exam-info/page.tsx
@@ -23,7 +23,7 @@ const ExamInfo = () => {
 
   return (
     <div className="bg-gray0">
-      <Button onStep={setStep('ExamInfo')} Icon={Icon} onMove={onMove}>
+      <Button onStep={setStep('ExamInfo')} Icon={Icon} onClick={onMove}>
         접수하기
       </Button>
       <div className="flex flex-col gap-y-5 m-5 mt-4">

--- a/src/app/(main)/home/goal-setting/page.tsx
+++ b/src/app/(main)/home/goal-setting/page.tsx
@@ -1,15 +1,22 @@
 'use client';
 
 import * as React from 'react';
+import { useRecoilValue } from 'recoil';
 
+import Button from '@/components/common/Button';
 import PreparationPeriodSetting from '@/components/home/goal-setting/PreparationPeriodSetting';
 import SelectCertification from '@/components/home/goal-setting/SelectCertification';
 import SetDailyGoals from '@/components/home/goal-setting/SetDailyGoals';
 import SetGoalScore from '@/components/home/goal-setting/SetGoalScore';
+import { postGoalSettingData } from '@/lib/api/home';
+import { goalSettingState } from '@/recoil/home/atom';
 
 const GoalSetting = () => {
+  const goalSettingData = useRecoilValue(goalSettingState);
+
   return (
     <div className="flex flex-col gap-y-8 mx-5">
+      <Button onClick={() => {postGoalSettingData(goalSettingData);}} className={'absolute right-0 w-fit'}>저장</Button>
       {/*자격증 선택*/}
       <SelectCertification />
       {/*목표 점수 설정*/}
@@ -22,4 +29,3 @@ const GoalSetting = () => {
   );
 };
 export default GoalSetting;
-

--- a/src/app/(main)/home/layout.tsx
+++ b/src/app/(main)/home/layout.tsx
@@ -10,7 +10,7 @@ export default function layout({ children }: { children: React.ReactNode }) {
   const [step, setStep] = useRecoilState<'Home' | 'ExamInfo'>(layoutState);
 
   return (
-    <div className="bg-gray0">
+    <div className="">
       {step == 'Home' ? (
         <div>
           <Header /> {children} <NavBar />

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -20,7 +20,7 @@ export default function Home() {
     <div>
       <div>홈페이지 입니다.</div>
       {/* TODO: className 컴포넌트로 빼기 */}
-      <Button className={'border-gray-button'} onMove={moveExamInfo} Icon={Icon} onStep={setStep('Home')}>
+      <Button className={'border-gray-button'} onClick={moveExamInfo} Icon={Icon} onStep={setStep('Home')}>
         응시정보 확인
       </Button>
     </div>

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -7,22 +7,20 @@ interface Props {
   children?: React.ReactNode;
   className: string;
   Icon?: (props: React.SVGProps<SVGSVGElement>) => JSX.Element;
-  onMove: () => void;
-  onStep: React.Dispatch<React.SetStateAction<string>>;
+  onClick: (data?: Object) => void;
+  onStep?: React.Dispatch<React.SetStateAction<string>>;
 }
 const Button = (props: Props) => {
-  const { children, className, Icon, onMove, onStep } = props;
+  const { children, className, Icon, onClick, onStep } = props;
   return (
     <button
       onClick={() => {
-        onMove();
-        onStep;
+        onClick();
+        onStep ? onStep : null;
       }}
       className={twMerge('bg-blue-button', className)}>
       <div>{children}</div>
-      <div className="mt-[2px]">
-        <Icon />
-      </div>
+      <div className="mt-[2px]">{Icon ? <Icon /> : null}</div>
     </button>
   );
 };

--- a/src/components/common/FilterModal.tsx
+++ b/src/components/common/FilterModal.tsx
@@ -3,8 +3,10 @@
 import React from 'react';
 import { twMerge } from 'tailwind-merge';
 
+import { Certificate } from '@/types/global';
+
 interface Props {
-  data: string[];
+  data: Certificate[];
   className: string;
   setDataState: React.Dispatch<React.SetStateAction<string>>;
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -17,19 +19,23 @@ const FilterModal = (props: Props) => {
   const { data, className, setDataState, setIsOpen } = props;
   return (
     <div className={twMerge('border-[1px] border-gray2 bg-white rounded-[16px] py-2 z-10', className)}>
-      {data.map((datum, index) => {
-        return (
-          <div
-            key={index}
-            className="text-h4 text-gray3 py-3 px-4 hover:text-black transition"
-            onClick={() => {
-              setDataState(datum);
-              setIsOpen(false);
-            }}>
-            {datum}
-          </div>
-        );
-      })}
+      {!data || data.length === 0 ? (
+        <div>error</div>
+      ) : (
+        data.map((datum, index) => {
+          return (
+            <div
+              key={index}
+              className="text-h4 text-gray3 py-3 px-4 hover:text-black transition"
+              onClick={() => {
+                setDataState(datum.certificateName);
+                setIsOpen(false);
+              }}>
+              {datum.certificateName}
+            </div>
+          );
+        })
+      )}
     </div>
   );
 };

--- a/src/components/home/goal-setting/DescriptionItem.tsx
+++ b/src/components/home/goal-setting/DescriptionItem.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 /**
  * 설정된 목표 기간에 따라 누적 공부량을 보여주는 설명 컴포넌트입니다.
- * @param children 에 elemenet를 넣어 내부 값을 다르게 표현할 수 있습니다.
+ * @param props children 에 Element 를 넣어 내부 값을 다르게 표현할 수 있습니다.
  */
 const DescriptionItem = (props: Props) => {
   const { children } = props;

--- a/src/components/home/goal-setting/DescriptionTag.tsx
+++ b/src/components/home/goal-setting/DescriptionTag.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 /**
  * 태그 형태의 설명 컴포넌트 입니다.
- * @param children 을 활용하여 안에 들어가는 내용을 설정할 수 있습니다.
+ * @param props children 을 활용하여 안에 들어가는 내용을 설정할 수 있습니다.
  */
 const DescriptionTag = (props: Props) => {
   const { children } = props;

--- a/src/components/home/goal-setting/SelectCertification.tsx
+++ b/src/components/home/goal-setting/SelectCertification.tsx
@@ -1,25 +1,44 @@
 'use client';
 
 import * as React from 'react';
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
-import SelectCertificationModal from '@/components/common/FilterModal';
 import FilterModal from '@/components/common/FilterModal';
 import GoalSettingTitle from '@/components/home/goal-setting/GoalSettingTitle';
-import { CERTIFICATION_CATEGORY } from '@/utils/common/certificationCategory';
+import useGetAllCertifications from '@/lib/hooks/useGetAllCertifications';
 
 /**
  목표 설정 페이지 중 자격증 선택 컴포넌트 입니다.
  */
 const SelectCertification = () => {
+  // 데이터 패칭
+  const { certificationsList, isLoading, isError } = useGetAllCertifications();
   //FilterModal 을 열고 닫는 state
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   // 선택된 자격증
-  const [selectCertification, setSelectCertification] = useState<string>('정보처리기사');
+  const [selectedCertification, setSelectedCertification] = useState<string>('정보처리기사');
   //FilterModal 을 열고 닫는 함수
   const modalHandler = () => {
     setIsModalOpen(!isModalOpen);
   };
+
+  // 모든 자격증 리스트 불러오는 함수
+  const getAllCertifications = useCallback(async () => {
+    return certificationsList;
+  }, []);
+
+  useEffect(() => {
+    if (certificationsList) {
+      getAllCertifications();
+    }
+    // if (isLoading) {
+    //
+    // }
+    //
+    // if (isError) {
+    //
+    // }
+  }, []);
 
   return (
     <div className="flex flex-col gap-y-2">
@@ -29,7 +48,7 @@ const SelectCertification = () => {
         <div className="relative flex items-center justify-between">
           <div className="flex gap-x-2 items-center">
             <SelectCertificationContentIcon />
-            <div className="text-h4">{selectCertification}</div>
+            <div className="text-h4">{selectedCertification}</div>
           </div>
           {isModalOpen ? <DropDownOnIcon /> : <DropDownOffIcon />}
         </div>
@@ -38,8 +57,8 @@ const SelectCertification = () => {
       {isModalOpen ? (
         <FilterModal
           setIsOpen={setIsModalOpen}
-          setDataState={setSelectCertification}
-          data={CERTIFICATION_CATEGORY}
+          setDataState={setSelectedCertification}
+          data={certificationsList.result}
           className={'absolute top-[134px] w-[90%]'}
         />
       ) : null}

--- a/src/components/home/goal-setting/SelectCertification.tsx
+++ b/src/components/home/goal-setting/SelectCertification.tsx
@@ -17,6 +17,7 @@ const SelectCertification = () => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   // 선택된 자격증
   const [selectedCertification, setSelectedCertification] = useState<string>('정보처리기사');
+
   //FilterModal 을 열고 닫는 함수
   const modalHandler = () => {
     setIsModalOpen(!isModalOpen);

--- a/src/components/home/goal-setting/SelectRepeatDayItem.tsx
+++ b/src/components/home/goal-setting/SelectRepeatDayItem.tsx
@@ -4,17 +4,17 @@ import { useState } from 'react';
 import * as React from 'react';
 import { useRecoilState } from 'recoil';
 
-import { mockExamDay, studyTimeDay } from '@/recoil/atom';
+import { goalSettingState } from '@/recoil/home/atom';
 
 interface Props {
-  used: string; // 사용된 용도 (모의고사 MockList, 공부시간 StudyTime)
+  usage: string; // 사용된 용도 (모의고사 MockList, 공부시간 StudyTime)
 }
 
 /**
  * 월, 화, 수, 목, 금, 토, 일 목표를 설정할 수 있는 컴포넌트입니다.
  */
 const SelectRepeatDayItem = (props: Props) => {
-  const { used } = props;
+  const { usage } = props;
   //각 버튼을 눌렀을 때, 눌렸는지를 확인하는 state
   const [isMonthClick, setIsMonthClick] = useState<boolean>(false);
   const [isTuesClick, setIsTuesClick] = useState<boolean>(false);
@@ -25,26 +25,38 @@ const SelectRepeatDayItem = (props: Props) => {
   const [isSunClick, setIsSunClick] = useState<boolean>(false);
 
   // 요일 리스트를 담은 state
-  const [mockExamDays, setMockExamDays] = useRecoilState<number[]>(mockExamDay);
-  const [studyTimeDays, setStudyTimeDays] = useRecoilState<number[]>(studyTimeDay);
+  let [goalSettingData, setGoalSettingData] = useRecoilState(goalSettingState);
 
   /**
    * 사용된 용도에 따라(모의고사 - MockExam, 공부시간 - StudyTime)
    * 요일 리스트에 요일을 추가하는 리스트 (2번 클릭 될 경우에는 리스트 제거)
+   * @param dayOfWeek 요일 [일: 1 ~ 토: 6]
    */
-  const addList = (index: number) => {
-    if (used == 'MockExam') {
-      if (!mockExamDays.includes(index)) {
-        setMockExamDays((mockExamDays) => [...mockExamDays, index]);
+  const addList = (dayOfWeek: number) => {
+    if (usage == 'MockExam') {
+      if (!goalSettingData.mockExamRepeatDays.includes(dayOfWeek)) {
+        setGoalSettingData((prevGoalSettingData) => ({
+          ...prevGoalSettingData,
+          mockExamRepeatDays: [...prevGoalSettingData.mockExamRepeatDays, dayOfWeek],
+        }));
       } else {
-        setMockExamDays(mockExamDays.filter((day) => day != index));
+        setGoalSettingData((prevGoalSettingData) => ({
+          ...prevGoalSettingData,
+          mockExamRepeatDays: [...prevGoalSettingData.mockExamRepeatDays].filter((day) => day != dayOfWeek),
+        }));
       }
     }
-    if (used == 'StudyTime') {
-      if (!studyTimeDays.includes(index)) {
-        setStudyTimeDays((studyTimeDays) => [...studyTimeDays, index]);
+    if (usage == 'StudyTime') {
+      if (!goalSettingData.studyRepeatDays.includes(dayOfWeek)) {
+        setGoalSettingData((prevGoalSettingData) => ({
+          ...prevGoalSettingData,
+          studyRepeatDays: [...prevGoalSettingData.studyRepeatDays, dayOfWeek],
+        }));
       } else {
-        setStudyTimeDays(studyTimeDays.filter((day) => day != index));
+        setGoalSettingData((prevGoalSettingData) => ({
+          ...prevGoalSettingData,
+          studyRepeatDays: [...prevGoalSettingData.studyRepeatDays].filter((day) => day != dayOfWeek),
+        }));
       }
     }
   };

--- a/src/components/home/goal-setting/SetGoalScore.tsx
+++ b/src/components/home/goal-setting/SetGoalScore.tsx
@@ -1,29 +1,28 @@
 'use client';
 
 import * as React from 'react';
-import { useState } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
 import GoalSettingTitle from '@/components/home/goal-setting/GoalSettingTitle';
 import SetGoalsItem from '@/components/home/goal-setting/SetGoalsItem';
+import { goalSettingState } from '@/recoil/home/atom';
 
 /**
  * 목표 점수를 설정하는 컴포넌트
  */
 const SetGoalScore = () => {
-  //목표 점수 횟수 증가
-  let [goalScoreCount, setGoalScoreCount] = useState<number>(0);
+  const goalData = useRecoilValue(goalSettingState);
+
   return (
     <div className="flex flex-col gap-y-2">
       <GoalSettingTitle Icon={SetGoalScoreIcon}>목표 점수 설정</GoalSettingTitle>
 
       <SetGoalsItem
-        use={'goalScore'}
+        usage={'goalScore'}
         goalString={'총점'}
         unitString={'점'}
-        actionString={goalScoreCount == 100 ? '받기' : '이상 받기'} // 총점 변경
+        actionString={goalData.goalScore == 100 ? '받기' : '이상 받기'} // 총점 변경
         ContentIcon={SetGoalScoreContentIcon}
-        count={goalScoreCount}
-        setCount={setGoalScoreCount}
       />
     </div>
   );

--- a/src/lib/api/home.ts
+++ b/src/lib/api/home.ts
@@ -1,0 +1,12 @@
+import { GoalSettingInfo } from '@/types/global';
+
+import { client } from '../axios';
+
+export const postGoalSettingData = async (goalSettingInfo: GoalSettingInfo) => {
+  try {
+    const { data } = await client.post('/1/goals', goalSettingInfo);
+    return data;
+  } catch (e) {
+    console.error(e);
+  }
+};

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+const client = axios.create({
+  baseURL: 'http://cercat.p-e.kr/api/v1',
+  headers: {
+    'Content-type': 'application/json',
+  },
+  withCredentials: true,
+});
+
+export const swrGetFetcher = (url: string) => client.get(url).then((res) => res.data);
+
+export { client };

--- a/src/lib/hooks/useGetAllCertifications.tsx
+++ b/src/lib/hooks/useGetAllCertifications.tsx
@@ -1,0 +1,20 @@
+import { AxiosResponse } from 'axios';
+import useSWR from 'swr';
+
+import { swrGetFetcher } from '@/lib/axios';
+import { Certificate } from '@/types/global';
+
+const useGetAllCertifications = () => {
+  const { data, error } = useSWR<AxiosResponse<Certificate[]>>('/certificates', swrGetFetcher);
+
+  const parseResultList = data?.result.map((item: Certificate) => item).flat();
+
+  return {
+    certificationsList: {
+      result: parseResultList ? parseResultList : [],
+    },
+    isLoading: !error && !data,
+    isError: error,
+  };
+};
+export default useGetAllCertifications;

--- a/src/recoil/home/atom.ts
+++ b/src/recoil/home/atom.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { atom } from 'recoil';
+
+import { GoalSettingInfo } from '@/types/global';
+
+//목표 설정 state
+export let goalSettingState = atom<GoalSettingInfo>({
+  key: 'goalSettingState',
+  default: {
+    goalScore: 100,
+    prepareStartDateTime: '2024-01-21T06:45:07.833Z',
+    prepareFinishDateTime: '2024-01-21T06:45:07.833Z',
+    goalPrepareDays: 0,
+    mockExamsPerDay: 0,
+    goalMockExams: 0,
+    mockExamRepeatDays: [],
+    studyTimePerDay: 0,
+    goalStudyTime: 0,
+    studyRepeatDays: [],
+  },
+});

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -37,14 +37,10 @@ export interface SpecificSubject {
   totalProblems: number;
 }
 
-// 온보딩 관심 자격증 리스트
-export const LicenseInfo: Array<License> = [];
-
-// 온보딩 관심 자격증 리스트의 객체 형태 자격증 번호
-interface License {
-  // TODO: 백엔드 API 나오는것 보고 변경될 예정
-  id: string;
-  title: string;
+// 자격증
+interface Certificate {
+  certificateId: number;
+  certificateName: string;
 }
 
 // 자격증 정보 공통 분류

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -71,3 +71,17 @@ interface CommonTitleType {
   qualifications: ExamInfoCommonType;
   criteria: ExamInfoCommonType;
 }
+
+// 목표 설정 type
+interface GoalSettingInfo {
+  goalScore: number;
+  prepareStartDateTime: string;
+  prepareFinishDateTime: string;
+  goalPrepareDays: number;
+  mockExamsPerDay: number;
+  goalMockExams: number;
+  mockExamRepeatDays: number[];
+  studyTimePerDay: number;
+  goalStudyTime: number;
+  studyRepeatDays: number[];
+}


### PR DESCRIPTION
## ✨ 구현 기능 명세

- /api/v1/{certifiactionId}/goals post 요청을 통해 자격증마다 목표 설정 데이터를 추가하였습니다.
- /api/v1/certificates swr과 axios를 사용하여 get하여, 자격증 종류를 불러왔습니다. (자격증 선택 -> 디자인팀과 협의하여 삭제될 수 있음)

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

## ✅ PR Point

1.  post 요청, get 요청 일단 기능상 문제는 없는데, 코드를 깔끔하게 짜는게 어려운 것 같아요. 이 부분 같이 봐주시면 감사하겠습니다!
2. recoil의 state를 props로 보내면 에러가 나서 각 컴포넌트를 용도(usage)에 따라서 if문 처리를 많이 했는데..(예를들어 usage == "mockExam" ? 뭘 하고 : usage == "StudyTime" ? : 뭘해라 : null 이런식으로) 이 부분을 개선하고 싶습니다. (확장성이 매우 떨어져서 아쉽습니다.)

## 😭 어려웠던 점

1. state끼리의 계산이 필요한 상황이었고, 이를 또 RecoilState에 반영해서 post 요청을 해야했어서 비동기 요청 때문에 애를 많이 썼습니다. 
2. calculatePreparingPeriod 함수를 사용할 때, 무한 호출이 되는 에러가 발생하였고, 그 이유를 찾아본 결과 calculatePreparingPeriod 함수 내에서 상태를 업데이트하면 해당 함수가 호출될 때마다 컴포넌트가 리렌더링되며. 이 때, 리렌더링에 의해 다시 calculatePreparingPeriod 가 호출되고 상태가 업데이트되면, 이 과정이 무한히 반복된다는 것을 알게 되어 useEffect에 dep를 조작하여 무한 루프를 방지하였습니다.

- 결론 : ChatGPT는 신이에요

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
