### PR TITLE
[#37]자격증 응시 정보 조회 API 연동 

### DIFF
--- a/src/app/(main)/home/exam-info/page.tsx
+++ b/src/app/(main)/home/exam-info/page.tsx
@@ -1,18 +1,25 @@
 'use client';
 
+import { format, getHours } from 'date-fns';
 import { useRouter } from 'next/navigation';
 import * as React from 'react';
+import { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 
 import Button from '@/components/common/Button';
 import ExamInfoItem from '@/components/home/ExamInfoItem';
+import useGetCertificationInfo from '@/lib/hooks/useGetCertificationInfo';
 import { layoutState } from '@/recoil/atom';
-//TODO: 백엔드에서 과목번호주면 처리
-import { COMPUTER_ABILITY_TEST_LEVEL_1 } from '@/utils/home/exam-info/ComputerAbilityTestLevel1';
-import { COMPUTER_ABILITY_TEST_LEVEL_2 } from '@/utils/home/exam-info/ComputerAbilityTestLevel2';
-
+import { certificationInfoState } from '@/recoil/home/atom';
+import { CertificateInfoType, GoalSettingInfo } from '@/types/global';
+import { commonTitle } from '@/utils/exam-info/CommonTitle';
 
 const ExamInfo = () => {
+  // 데이터 패칭
+  const { certificationInfo, isLoading, isError } = useGetCertificationInfo();
+
+  const [data, setData] = useRecoilState(certificationInfoState);
+
   const [step, setStep] = useRecoilState(layoutState);
   const router = useRouter();
 
@@ -21,16 +28,77 @@ const ExamInfo = () => {
     router.push('/home');
   };
 
+  /**
+   * Recoil 상태를 초기화하는 함수
+   * @param apiResponse certificationInfo.result
+   */
+  const initializeCertificationInfoState = (apiResponse: CertificateInfoType) => {
+    return {
+      examSchedule: {
+        applicationStartDateTime:
+          '• 접수 시작: ' + format(apiResponse.examSchedule.applicationStartDateTime, 'yyyy.MM.dd'),
+        applicationDeadlineDateTime:
+          '• 접수 종료: ' + format(apiResponse.examSchedule.applicationDeadlineDateTime, 'yyyy.MM.dd'),
+        examDateTime: '• 시험 날짜: ' + format(apiResponse.examSchedule.examDateTime, 'yyyy.MM.dd'),
+      },
+      examFee: {
+        writtenExamFee: '• 필기 시험: ' + apiResponse.examFee.writtenExamFee.toString() + '원',
+        practicalExamFee: '• 실기 시험: ' + apiResponse.examFee.practicalExamFee.toString() + '원',
+      },
+      examTimeLimit: {
+        writtenExamTimeLimit:
+          '• 필기 시험 시간: ' + getHours(apiResponse.examTimeLimit.writtenExamTimeLimit).toString() + '분',
+        practicalExamTimeLimit:
+          '• 실기 시험 시간: ' + apiResponse.examTimeLimit.practicalExamTimeLimit.toString() + '분',
+      },
+      passingCriteria: {
+        subjectPassingCriteria:
+          '• 과목당 합격 기준: ' + apiResponse.passingCriteria.subjectPassingCriteria.toString() + '점',
+        totalAvgCriteria: '• 전체 합격 기준: ' + apiResponse.passingCriteria.totalAvgCriteria.toString() + '점',
+        practicalPassingCriteria:
+          '• 실기 시험 합격 기준: ' + apiResponse.passingCriteria.practicalPassingCriteria.toString() + '점',
+      },
+      subjectsInfo: apiResponse.subjectsInfo,
+      description: apiResponse.description,
+      examFormat: apiResponse.examFormat,
+      examEligibility: apiResponse.examEligibility,
+    };
+  };
+
+  /**
+   * API 에서 데이터를 가져와 Recoil 상태 업데이트 해주는 함수
+   */
+  const fetchDataAndUpdateState = async () => {
+    try {
+      const response = certificationInfo;
+      console.log('response', response);
+      if (response) {
+        const initialState: CertificateInfoType = initializeCertificationInfoState(response.result);
+        setData(initialState);
+      } else {
+        // 에러 처리를 수행할 수 있습니다.
+        console.error('Failed to fetch goal setting data');
+      }
+    } catch (error) {
+      // 네트워크 오류 또는 다른 예외에 대한 처리를 수행할 수 있습니다.
+      console.error('Error fetching goal setting data:', error);
+    }
+  };
+
+  // 컴포넌트가 마운트될 때 데이터 가져오기
+  useEffect(() => {
+    fetchDataAndUpdateState();
+  }, [certificationInfo]);
+
   return (
     <div className="bg-gray0">
       <Button onStep={setStep('ExamInfo')} Icon={Icon} onClick={onMove}>
         접수하기
       </Button>
       <div className="flex flex-col gap-y-5 m-5 mt-4">
-        {/*TODO: 백엔드에서 과목 받으면 그에 따라 처리*/}
-        {Object.entries(SOCIAL_RESEARCH_ANALYST_TEST_LEVEL2).map(([index, item]) => (
-          <div key={index}>
-            <ExamInfoItem Icon={item.Icon} title={item.title} content={item.content} />
+        {Object.entries(data).map(([key, item]) => (
+          <div key={key}>
+            <ExamInfoItem Icon={commonTitle[key].Icon} title={commonTitle[key].title} content={item} />
           </div>
         ))}
       </div>
@@ -41,20 +109,8 @@ export default ExamInfo;
 
 function Icon(props) {
   return (
-    <svg
-      width={16}
-      height={17}
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      {...props}
-    >
-      <path
-        d="M5 11.5l6-6M5 5.5h6v6"
-        stroke="#ffffff"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+    <svg width={16} height={17} fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d="M5 11.5l6-6M5 5.5h6v6" stroke="#ffffff" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
 }
-

--- a/src/components/home/ExamInfoItem.tsx
+++ b/src/components/home/ExamInfoItem.tsx
@@ -1,11 +1,15 @@
 'use client';
 
+import { string } from 'prop-types';
 import React from 'react';
 
+import { CertificateInfoType } from '@/types/global';
+
+// @ts-ignore
 interface ExamInfoItemProps {
   Icon: (props: React.SVGProps<SVGSVGElement>) => JSX.Element;
   title: string;
-  content: string;
+  content: string | Object;
 }
 const ExamInfoItem: React.FC<ExamInfoItemProps> = ({ Icon, title, content }) => {
   return (
@@ -15,7 +19,11 @@ const ExamInfoItem: React.FC<ExamInfoItemProps> = ({ Icon, title, content }) => 
         <div className="text-h3 font-semibold">{title}</div>
       </div>
       <div className="h-[1px] bg-gray1 my-2"></div>
-      <div className="text-h4">{content}</div>
+      <div className="text-h4">
+        {Object.entries(content).map(([key, value]) => {
+          return value.length == 1 ? value : <div>{value}</div>;
+        })}
+      </div>
     </div>
   );
 };

--- a/src/lib/hooks/useGetCertificationInfo.tsx
+++ b/src/lib/hooks/useGetCertificationInfo.tsx
@@ -1,0 +1,15 @@
+import { AxiosResponse } from 'axios';
+import useSWR from 'swr';
+
+import { swrGetFetcher } from '@/lib/axios';
+
+const useGetCertificationInfo = () => {
+  const { data, error } = useSWR<AxiosResponse>('certificates/1/exam-infos', swrGetFetcher);
+
+  return {
+    certificationInfo: data,
+    isLoading: !error && !data,
+    isError: error,
+  };
+};
+export default useGetCertificationInfo;

--- a/src/recoil/home/atom.ts
+++ b/src/recoil/home/atom.ts
@@ -2,7 +2,36 @@
 
 import { atom } from 'recoil';
 
-import { GoalSettingInfo } from '@/types/global';
+import { CertificateInfoType, GoalSettingInfo } from '@/types/global';
+
+//자격증 응시 정보 state
+export const certificationInfoState = atom<CertificateInfoType>({
+  key: 'certificationInfoState',
+  default: {
+    description: '',
+    examSchedule: {
+      applicationStartDateTime: '2024-01-23T07:40:42.986Z',
+      applicationDeadlineDateTime: '2024-01-23T07:40:42.986Z',
+      examDateTime: '2024-01-23T07:40:42.986Z',
+    },
+    subjectsInfo: '',
+    examFormat: '',
+    examFee: {
+      writtenExamFee: '',
+      practicalExamFee: '',
+    },
+    examTimeLimit: {
+      writtenExamTimeLimit: '',
+      practicalExamTimeLimit: '',
+    },
+    passingCriteria: {
+      subjectPassingCriteria: '',
+      totalAvgCriteria: '',
+      practicalPassingCriteria: '',
+    },
+    examEligibility: '',
+  },
+});
 
 //목표 설정 state
 export let goalSettingState = atom<GoalSettingInfo>({

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -37,17 +37,6 @@ export interface SpecificSubject {
   totalProblems: number;
 }
 
-// 자격증 정보 공통 분류
-export interface ExamInfoCommonCategory {
-  intro: ExamInfoCommonType;
-  schedule: ExamInfoCommonType;
-  subject: ExamInfoCommonType;
-  fee: ExamInfoCommonType;
-  method: ExamInfoCommonType;
-  qualifications: ExamInfoCommonType;
-  criteria: ExamInfoCommonType;
-}
-
 // 자격증 응시 정보의 공통 타입
 export interface ExamInfoCommonType {
   Icon: (props: React.SVGProps<SVGSVGElement>) => JSX.Element;
@@ -57,13 +46,40 @@ export interface ExamInfoCommonType {
 
 // 공통 제목 type
 interface CommonTitleType {
-  intro: ExamInfoCommonType;
-  schedule: ExamInfoCommonType;
-  subject: ExamInfoCommonType;
-  fee: ExamInfoCommonType;
-  method: ExamInfoCommonType;
-  qualifications: ExamInfoCommonType;
-  criteria: ExamInfoCommonType;
+  description: ExamInfoCommonType;
+  examFee: ExamInfoCommonType;
+  examSchedule: ExamInfoCommonType;
+  subjectsInfo: ExamInfoCommonType;
+  examFormat: ExamInfoCommonType;
+  examEligibility: ExamInfoCommonType;
+  examTimeLimit: ExamInfoCommonType;
+  passingCriteria: ExamInfoCommonType;
+}
+
+//자격증 응시 정보 type
+interface CertificateInfoType {
+  examSchedule: {
+    applicationStartDateTime: string;
+    applicationDeadlineDateTime: string;
+    examDateTime: string;
+  };
+  examFee: {
+    writtenExamFee: string;
+    practicalExamFee: string;
+  };
+  examTimeLimit: {
+    writtenExamTimeLimit: string;
+    practicalExamTimeLimit: string;
+  };
+  passingCriteria: {
+    subjectPassingCriteria: string;
+    totalAvgCriteria: string;
+    practicalPassingCriteria: string;
+  };
+  subjectsInfo: string;
+  description: string;
+  examFormat: string;
+  examEligibility: string;
 }
 
 // 목표 설정 type

--- a/src/utils/exam-info/CommonTitle.tsx
+++ b/src/utils/exam-info/CommonTitle.tsx
@@ -1,14 +1,16 @@
-import { CommonTitleType, ExamInfoCommonType } from '@/types/global';
 import * as React from 'react';
 
-export const CommonTitle: CommonTitleType = {
-  intro: { Icon: IntroIcon, title: '자격증 소개' },
-  schedule: { Icon: ScheduleIcon, title: '시험 일정' },
-  subject: { Icon: SubjectIcon, title: '시험 과목' },
-  fee: { Icon: FeeIcon, title: '응시료' },
-  method: { Icon: MethodIcon, title: '시험 방식' },
-  qualifications: { Icon: QualificationsIcon, title: '응시 자격' },
-  criteria: { Icon: CriteriaIcon, title: '합격 기준' },
+import { CommonTitleType } from '@/types/global';
+
+export const commonTitle: CommonTitleType = {
+  description: { Icon: IntroIcon, title: '자격증 소개' },
+  examFee: { Icon: FeeIcon, title: '응시료' },
+  examSchedule: { Icon: ScheduleIcon, title: '시험 일정' },
+  subjectsInfo: { Icon: SubjectIcon, title: '시험 과목' },
+  examFormat: { Icon: MethodIcon, title: '시험 방식' },
+  examEligibility: { Icon: QualificationsIcon, title: '응시 자격' },
+  examTimeLimit: { Icon: QualificationsIcon, title: '시험 시간' },
+  passingCriteria: { Icon: CriteriaIcon, title: '합격 기준' },
 };
 
 function IntroIcon(props: React.SVGProps<SVGSVGElement>) {


### PR DESCRIPTION
## ✨ 구현 기능 명세

기존 자격증 응시 정보 데이터를 utils 더미데이터로 추가하였는데, 이부분을 백엔드 api 연동을 통해 데이터를 불러왔습니다.

## ✅ PR Point

* github branch를 바꾸지 않고 작업해서 `feature-goal-setting_edit`으로 작업했습니다..

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
