### PR TITLE
[#68] 게시글 수정 기능 구현

### DIFF
--- a/src/app/(main)/community/[category]/page.tsx
+++ b/src/app/(main)/community/[category]/page.tsx
@@ -4,6 +4,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import WriteExplanationPost from '@/components/community/WriteExplanationPost';
 import WriteTipPost from '@/components/community/WriteTipPost';
 import WriteNormalPost from '@/components/community/WriteNormalPost';
+import EditPost from '@/components/community/EditPost';
 
 export default function CommunityCategoryPage() {
   const pathname = usePathname();
@@ -11,11 +12,12 @@ export default function CommunityCategoryPage() {
 
   return (
     <div>
-      <WriteNormalPost />
+      {/*<EditPost />*/}
+      {/*<WriteNormalPost />*/}
       {/*<WriteTipPost />*/}
       {/*<WriteExplanationPost />*/}
       {/*<p>{pathname} 페이지</p>*/}
-      {/*<button onClick={() => router.replace(`${pathname}/1`)}>게시글 상세로 이동하기</button>*/}
+      <button onClick={() => router.replace(`${pathname}/1`)}>게시글 상세로 이동하기</button>
     </div>
   );
 }

--- a/src/components/common/FilterModal.tsx
+++ b/src/components/common/FilterModal.tsx
@@ -4,12 +4,12 @@ import React, { useEffect } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 import { Certificate } from '@/types/global';
-import { PostDataType, YearsAndRounds } from '@/types/community/type';
+import { CreatePostDataType, YearsAndRounds } from '@/types/community/type';
 
 interface Props {
   data: [];
   className?: string;
-  setDataState: React.Dispatch<React.SetStateAction<PostDataType>>;
+  setDataState: React.Dispatch<React.SetStateAction<CreatePostDataType>>;
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 

--- a/src/components/common/MockExamYearsFilter.tsx
+++ b/src/components/common/MockExamYearsFilter.tsx
@@ -1,10 +1,10 @@
 import { Certificate } from '@/types/global';
 import React from 'react';
-import { PostDataType, YearsAndRounds } from '@/types/community/type';
+import { CreatePostDataType, YearsAndRounds } from '@/types/community/type';
 
 interface Props {
   data: YearsAndRounds;
-  setDataState: React.Dispatch<React.SetStateAction<PostDataType>>;
+  setDataState: React.Dispatch<React.SetStateAction<CreatePostDataType>>;
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 const MockExamYearsFilter = (props: Props) => {

--- a/src/components/community/EditPost.tsx
+++ b/src/components/community/EditPost.tsx
@@ -1,0 +1,611 @@
+'use client';
+
+import Image from 'next/image';
+import React, { FormEvent, useEffect, useRef, useState } from 'react';
+import { useRecoilState } from 'recoil';
+
+import FilterModal from '@/components/common/FilterModal';
+import MockExamYearsFilter from '@/components/common/MockExamYearsFilter';
+import ImageDeleteButton from '@/components/community/ImageDeleteButton';
+import { putPostDetail } from '@/lib/api/community';
+import useGetMockExamYearsAndRounds from '@/lib/hooks/useGetMockExamYearsAndRounds';
+import useGetPost from '@/lib/hooks/useGetPost';
+import useMockExamQuestions from '@/lib/hooks/useMockExamQuestions';
+import { editPostDataState, imagePreviewsState, imageUrlListState, pastImageUrlsState } from '@/recoil/community/atom';
+import { EditPostDataType, TipPostTagType } from '@/types/community/type';
+
+const EditPost = () => {
+  const { postDetailData } = useGetPost();
+  const { questions } = useMockExamQuestions();
+  const { examYearWithRounds } = useGetMockExamYearsAndRounds();
+  const [editPostData, setEditPostData] = useRecoilState(editPostDataState);
+  const [onlineCourseInputs, setOnlineCourseInputs] = useState<string[]>([]);
+  const [workbookInputs, setWorkbookInputs] = useState<string[]>([]);
+  const imgRef = useRef<HTMLInputElement>(null);
+  const [imagePreviews, setImagePreviews] = useRecoilState<string[]>(imagePreviewsState);
+  const [imageUrlList, setImageUrlList] = useRecoilState<File[]>(imageUrlListState);
+  const [pastImageUrls, setPastImageUrls] = useRecoilState<string[]>(pastImageUrlsState);
+  const [isEmpty, setIsEmpty] = useState(false);
+  const [isQuestionSequenceNumeric, setIsQuestionSequenceNumeric] = useState(true);
+  const [questionSequence, setQuestionSequence] = useState(0);
+  const [isYearsFilterOpen, setIsYearsFilterOpen] = useState(false);
+  const [isRoundsFilterOpen, setIsRoundsFilterOpen] = useState(false);
+  // 기존 코드는 유지하고, 입력 필드의 상태를 관리하기 위한 새로운 state를 추가합니다.
+  const [inputValue, setInputValue] = useState('');
+
+  /**
+   * 해설 게시글 Recoil 상태를 초기화하는 함수
+   * @param apiResponse postDetailData.result
+   */
+  const initializeCommentaryEditPostData = (apiResponse) => {
+    return {
+      postId: apiResponse.postId,
+      title: apiResponse.title,
+      content: apiResponse.content,
+      examYear: apiResponse.question.mockExam.examYear,
+      round: apiResponse.question.mockExam.round,
+      questionSequence: apiResponse.question.questionSeq,
+      removeImageUrls: [],
+    };
+  };
+
+  /**
+   * 꿀팁 게시글 Recoil 상태를 초기화하는 함수
+   * @param apiResponse postDetailData.result
+   */
+  const initializeTipEditPostData = (apiResponse) => {
+    return {
+      postId: apiResponse.postId,
+      title: apiResponse.title,
+      content: apiResponse.content,
+      removeImageUrls: [],
+    };
+  };
+
+  /**
+   * 자유 게시글 Recoil 상태를 초기화하는 함수
+   * @param apiResponse postDetailData.result
+   */
+  const initializeNormalEditPostData = (apiResponse) => {
+    return {
+      postId: apiResponse.postId,
+      title: apiResponse.title,
+      content: apiResponse.content,
+      removeImageUrls: [],
+    };
+  };
+
+  /**
+   * API 에서 데이터를 가져와 Recoil 상태 업데이트 해주는 함수
+   */
+  const fetchDataAndUpdateState = async () => {
+    try {
+      const response = await postDetailData;
+      if (response) {
+        // 해설 게시글일 때,
+        if (postDetailData?.hasOwnProperty('mockExam')) {
+          const initialCommentaryState: EditPostDataType = initializeCommentaryEditPostData(response);
+          setEditPostData(initialCommentaryState);
+        }
+        // 꿀팁 게시글일 때,
+        if (postDetailData?.hasOwnProperty('recommendTags')) {
+          const initialTipState: EditPostDataType = initializeTipEditPostData(response);
+          setEditPostData(initialTipState);
+        }
+        //자유게시글일 때,
+        if (!postDetailData?.hasOwnProperty('mockExam') && !postDetailData?.hasOwnProperty('recommendTags')) {
+          const initialNormalState: EditPostDataType = initializeNormalEditPostData(response);
+          setEditPostData(initialNormalState);
+        }
+        setPastImageUrls(postDetailData.postImages);
+      } else {
+        // 에러 처리를 수행할 수 있습니다.
+        console.error('Failed to fetch');
+      }
+    } catch (error) {
+      // 네트워크 오류 또는 다른 예외에 대한 처리를 수행할 수 있습니다.
+      console.error('Error fetching:', error);
+    }
+  };
+
+  // 컴포넌트가 마운트될 때 데이터 가져오기
+  useEffect(() => {
+    fetchDataAndUpdateState();
+  }, [postDetailData]);
+
+  /**
+   * 꿀팁 게시글 수정하기 전 과거 remonnedTags 값을 가져와서 onlineCourseInputs 값을 초기화해주는 함수
+   */
+  const updateNewOnlineCourseInput = () => {
+    if (postDetailData?.hasOwnProperty('recommendTags')) {
+      postDetailData.recommendTags.map((recommendTag: TipPostTagType) => {
+        if (!onlineCourseInputs.includes(recommendTag.tagName)) {
+          if (recommendTag.tagType === 'LECTURE') {
+            setOnlineCourseInputs((prevState) => [...prevState, recommendTag.tagName]);
+          }
+        }
+      });
+    }
+  };
+
+  /**
+   * 꿀팁 게시 과거 remonnedTags 값을 가져와서 workbookInputs 값을 초기화해주는 함수
+   */
+  const updateNewWorkBookInput = () => {
+    if (postDetailData?.hasOwnProperty('recommendTags')) {
+      postDetailData.recommendTags.map((recommendTag: TipPostTagType) => {
+        if (!workbookInputs.includes(recommendTag.tagName)) {
+          if (recommendTag.tagType === 'BOOK') {
+            setWorkbookInputs((prevState) => [...prevState, recommendTag.tagName]);
+          }
+        }
+      });
+    }
+  };
+
+  useEffect(() => {
+    updateNewOnlineCourseInput();
+    updateNewWorkBookInput();
+  }, [postDetailData]);
+
+  /**
+   * 추천 강의 새 입력 필드를 추가하는 함수
+   */
+  const addOnlineCourseInput = () => {
+    setOnlineCourseInputs([...onlineCourseInputs, '']); // 기존 입력 필드 목록에 빈 문자열을 추가
+  };
+
+  /**
+   * 추천 문제집 새 입력 필드를 추가하는 함수
+   */
+  const addWorkbookInputs = () => {
+    setWorkbookInputs([...workbookInputs, '']); // 기존 입력 필드 목록에 빈 문자열을 추가
+  };
+
+  /**
+   * 추천 인강 삭제
+   */
+  const deleteOnlineCourseInputs = (i: number) => {
+    const copyOnlineCourseInputs = [...onlineCourseInputs];
+    setOnlineCourseInputs(copyOnlineCourseInputs.filter((onlineCourseInput, index) => index != i));
+  };
+
+  /**
+   * 추천 문제집 삭제
+   */
+  const deleteWorkBookInputs = (i: number) => {
+    const copyWorkbookInputs = [...workbookInputs];
+    setWorkbookInputs(copyWorkbookInputs.filter((workBookInput, index) => index != i));
+  };
+
+  /**
+   * 추천 인강 입력 필드 값 변경 함수
+   */
+  const handleChangeOnlineCourseInput = (index: number, event: React.ChangeEvent<HTMLInputElement>) => {
+    const newInputs = [...onlineCourseInputs];
+    newInputs[index] = event.target.value; // 변경된 값을 해당 인덱스의 입력 필드에 반영
+    setOnlineCourseInputs(newInputs);
+  };
+
+  /**
+   * 추천 문제집 입력 필드 값 변경 함수
+   */
+  const handleChangeWorkBookInput = (index: number, event: React.ChangeEvent<HTMLInputElement>) => {
+    const newInputs = [...workbookInputs];
+    newInputs[index] = event.target.value; // 변경된 값을 해당 인덱스의 입력 필드에 반영
+    setWorkbookInputs(newInputs);
+  };
+
+  /**
+   * 문제 번호가 숫자로만 이루어졌는지 확인하는 함수
+   */
+  const isNumeric = (value: string) => {
+    setIsQuestionSequenceNumeric(/^\d+$/.test(value));
+  };
+
+  /**
+   * 이미지 업로드 및 미리보기 함수
+   */
+  const saveImgFile = async () => {
+    const files = imgRef.current?.files;
+    if (!files) return;
+
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
+      const reader = new FileReader();
+
+      reader.onloadend = () => {
+        setImagePreviews((prevImagePreviews) => [...prevImagePreviews, reader.result as string]);
+      };
+      reader.readAsDataURL(file);
+
+      setImageUrlList((prevImageUrlList) => [...prevImageUrlList, file]);
+    }
+  };
+
+  /**
+   * 문제 번호를 변경하는 함수
+   * @param value 문제 번호
+   */
+  const changePostDataQuestionSequence = (value: string) => {
+    setEditPostData((prevState) => ({
+      ...prevState,
+      questionSequence: parseInt(value),
+    }));
+  };
+
+  /**
+   * 게시글 제목을 변경하는 함수
+   * @param value 게시글 제목
+   */
+  const changePostDataTitle = (value: string) => {
+    setEditPostData((prevState) => ({
+      ...prevState,
+      title: value,
+    }));
+  };
+
+  /**
+   * 게시글 내용을 변경하는 함수
+   * @param value 게시글 내용
+   */
+  const changePostDataContent = (value: string) => {
+    setEditPostData((prevState) => ({
+      ...prevState,
+      content: value,
+    }));
+  };
+
+  /**
+   * 추천 인강, 추천 문제집 요구하는 post 타입으로 변경
+   */
+  const changeTags = () => {
+    onlineCourseInputs.filter((lecture) => lecture !== '');
+    workbookInputs.filter((book) => book !== '');
+
+    const updatedTags = [
+      ...onlineCourseInputs
+        .filter((lecture) => lecture !== '')
+        .map((lecture) => ({ tagType: 'LECTURE', tagName: lecture })),
+      ...workbookInputs.filter((book) => book !== '').map((book) => ({ tagType: 'BOOK', tagName: book })),
+    ];
+
+    setEditPostData((prevState) => ({
+      ...prevState,
+      newTags: updatedTags,
+    }));
+  };
+
+  // 해설 게시글일 때, 문제 번호를 컨트롤하는 inputValue state 값을 과거 데이터로 초기화
+  useEffect(() => {
+    setInputValue(editPostData.questionSequence?.toString() ?? '');
+  }, [editPostData.questionSequence]);
+
+  /**
+   * Input 이벤트에 따라 안내문구 변경 함수
+   * @param e input 이벤트
+   */
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    isNumeric(value);
+    setIsEmpty(value.length === 0);
+    setQuestionSequence(parseInt(value) || 0); // 입력값을 상태에 저장, NaN이면 0으로 설정
+
+    if (/^\d+$/.test(value) && value.length !== 0 && parseInt(value) < questions.length) {
+      changePostDataQuestionSequence(value);
+    }
+    setInputValue(value); // 입력 필드 상태 업데이트
+  };
+
+  /**
+   * 꿀팁 게시글 제출 함수 postData.tags 가 변경됨에 따라 아래의 useEffect 가 실행되어 제출됨.
+   */
+  const handleTipSubmit = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault();
+
+    changeTags(); // 태그 변경 함수 호출
+  };
+
+  useEffect(() => {
+    if (postDetailData?.hasOwnProperty('recommendTags')) {
+      // 태그가 업데이트된 후 실행할 로직
+      const formData = new FormData();
+      imageUrlList.forEach((file) => {
+        formData.append('images', file);
+      });
+      formData.append('request', new Blob([JSON.stringify(editPostData)], { type: 'application/json' }));
+
+      // API 호출 로직
+      putPostDetail(1, 'TIP', formData)
+        .then((response) => {
+          console.log(response);
+        })
+        .catch((error) => {
+          console.error('폼 제출 중 오류 발생:', error);
+        });
+    }
+  }, [editPostData.newTags]);
+
+  /**
+   * 자유 게시글, 해설 게시글 form 형식 제출 함수
+   */
+  const handleNormalAndCommentarySubmit = async (e: FormEvent) => {
+    e.preventDefault(); // 폼 제출 시 새로고침 방지
+    const formData = new FormData();
+
+    imageUrlList.forEach((file, index) => {
+      formData.append('images', file);
+    });
+
+    formData.append(
+      'request',
+      new Blob([JSON.stringify(editPostData)], {
+        type: 'application/json',
+      }),
+    );
+    try {
+      if (postDetailData?.hasOwnProperty('mockExam')) {
+        const response = await putPostDetail(1, 'COMMENTARY', formData); // API 호출
+        console.log('COMMENTARY', response.data);
+      }
+      if (!postDetailData?.hasOwnProperty('mockExam') && !postDetailData?.hasOwnProperty('recommendTags')) {
+        const response = await putPostDetail(1, 'NORMAL', formData); // API 호출
+        console.log('TIP', response.data);
+      }
+    } catch (error) {
+      console.error('폼 제출 중 오류 발생:', error);
+    }
+  };
+
+  return (
+    <div>
+      <form
+        onSubmit={
+          !postDetailData?.hasOwnProperty('mockExam') && !postDetailData?.hasOwnProperty('recommendTags')
+            ? handleNormalAndCommentarySubmit
+            : postDetailData?.hasOwnProperty('mockExam')
+              ? handleNormalAndCommentarySubmit
+              : handleTipSubmit
+        }>
+        <button type={'submit'} className={'p-3 bg-second text-white'}>
+          저장
+        </button>
+        {postDetailData?.hasOwnProperty('mockExam') && (
+          <div>
+            {/* 년도 선택 세션 */}
+            <div className={'flex flex-col relative gap-y-2'}>
+              <div className={'text-h3 font-bold ml-2'}>모의고사 연도 선택</div>
+              <div
+                onClick={() => {
+                  setIsYearsFilterOpen(!isYearsFilterOpen);
+                }}
+                className={'flex justify-between bg-gray0 rounded-[16px] py-3 px-4'}>
+                <div className={'text-h4'}>{editPostData.examYear}년</div>
+                {isYearsFilterOpen ? <DropUpIcon /> : <DropDownIcon />}
+              </div>
+              {isYearsFilterOpen && (
+                <MockExamYearsFilter
+                  data={examYearWithRounds?.examYearWithRounds}
+                  setIsOpen={setIsYearsFilterOpen}
+                  setDataState={setEditPostData}
+                />
+              )}
+            </div>
+
+            {/* 회차 선택 세션 */}
+            <div className={'flex flex-col relative gap-y-2'}>
+              <div className={'text-h3 font-bold ml-2'}>모의고사 회차 선택</div>
+              <div
+                onClick={() => {
+                  setIsRoundsFilterOpen(!isRoundsFilterOpen);
+                }}
+                className={'flex justify-between bg-gray0 rounded-[16px] py-3 px-4'}>
+                <div className={'text-h4'}>{editPostData.round}회차</div>
+                {isRoundsFilterOpen ? <DropUpIcon /> : <DropDownIcon />}
+              </div>
+              {isRoundsFilterOpen && (
+                <FilterModal
+                  data={
+                    postDetailData.mockExam.examYear
+                      ? examYearWithRounds?.examYearWithRounds[postDetailData.mockExam.examYear]
+                      : null
+                  }
+                  setDataState={setEditPostData}
+                  setIsOpen={setIsRoundsFilterOpen}
+                  className={'absolute w-full top-[100%]'}
+                />
+              )}
+            </div>
+
+            {/* 문제 번호 선택 세션 */}
+            <div className={'flex flex-col relative gap-y-2'}>
+              <div className={'text-h3 font-bold ml-2'}>문항 번호 입력</div>
+              <div>
+                <input
+                  value={inputValue}
+                  onChange={handleInputChange}
+                  className={'w-full bg-gray0 rounded-[16px] py-3 px-4 focus:outline-0'}></input>
+                {/* 경고 문구 세션 */}
+                {isEmpty ? <div className={'text-point ml-1'}>내용을 입력해주세요.</div> : null}
+                {!isQuestionSequenceNumeric && !isEmpty ? (
+                  <div className={'text-point ml-1'}>숫자만 입력해주세요.</div>
+                ) : null}
+                {questionSequence > questions?.length && !isEmpty && isQuestionSequenceNumeric ? (
+                  <div className={'text-point ml-1'}>전체 문제 수({questions?.length}) 이하의 숫자를 입력해주세요.</div>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* 제목, 글 작성 세션 */}
+        <div className={'flex flex-col gap-y-2 mt-[16px]'}>
+          <div className={'text-h3 font-bold ml-2'}>해설 작성</div>
+          <div className={'flex flex-col gap-y-3'}>
+            <input
+              onChange={(e) => {
+                changePostDataTitle(e.target.value);
+              }}
+              className={
+                'w-full border-gray2 border-[1px] rounded-[16px] py-3 px-4 placeholder:text-gray4 focus:outline-0'
+              }
+              value={editPostData.title}></input>
+            <textarea
+              onChange={(e) => {
+                changePostDataContent(e.target.value);
+              }}
+              value={editPostData.content}
+              className={
+                'w-full h-[300px] border-gray2 border-[1px] rounded-[16px] py-3 px-4 placeholder:text-gray4 focus:outline-0'
+              }></textarea>
+          </div>
+        </div>
+
+        {/* 인강 추천 태그 세션*/}
+        {postDetailData?.hasOwnProperty('recommendTags') && (
+          <div className={'flex flex-col gap-y-2 mt-[16px]'}>
+            <div className={'text-h3 font-bold ml-2'}>
+              추천 인강 <span className={'font-normal text-gray3 text-h4'}>(선택)</span>
+            </div>
+            <div className={'flex flex-col gap-y-3'}>
+              {onlineCourseInputs.map((input: string, index: number) => (
+                <div
+                  key={index}
+                  className={'flex justify-between w-full border-gray2 border-[1px] rounded-[16px] py-3 px-4'}>
+                  <input
+                    type="text"
+                    value={input}
+                    placeholder={'인강 제목'}
+                    className={'w-[90%] placeholder:text-gray4 focus:outline-0'}
+                    onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                      handleChangeOnlineCourseInput(index, event)
+                    }
+                  />
+                  <button
+                    type={'button'}
+                    onClick={() => deleteOnlineCourseInputs(index)}
+                    className={'bg-gray2 rounded-full p-1'}>
+                    x
+                  </button>
+                </div>
+              ))}
+            </div>
+            <button
+              onClick={() => addOnlineCourseInput()}
+              type={'button'}
+              className={'bg-second rounded-[16px] py-3 px-4 text-white text-h6'}>
+              + 추가
+            </button>
+          </div>
+        )}
+
+        {/* 문제집 추천 태그 세션*/}
+        {postDetailData?.hasOwnProperty('recommendTags') && (
+          <div className={'flex flex-col gap-y-2 mt-[16px]'}>
+            <div className={'text-h3 font-bold ml-2'}>
+              추천 문제집 <span className={'font-normal text-gray3 text-h4'}>(선택)</span>
+            </div>
+            <div className={'flex flex-col gap-y-3'}>
+              {workbookInputs.map((input: string, index: number) => (
+                <div
+                  key={index}
+                  className={'flex justify-between w-full border-gray2 border-[1px] rounded-[16px] py-3 px-4'}>
+                  <input
+                    type="text"
+                    value={input}
+                    placeholder={'문제집 제목'}
+                    className={'w-[90%] placeholder:text-gray4 focus:outline-0'}
+                    onChange={(event: React.ChangeEvent<HTMLInputElement>) => handleChangeWorkBookInput(index, event)}
+                  />
+                  <button
+                    type={'button'}
+                    onClick={() => deleteWorkBookInputs(index)}
+                    className={'bg-gray2 rounded-full p-1'}>
+                    x
+                  </button>
+                </div>
+              ))}
+            </div>
+            <button
+              onClick={() => addWorkbookInputs()}
+              type={'button'}
+              className={'bg-second rounded-[16px] py-3 px-4 text-white text-h6'}>
+              + 추가
+            </button>
+          </div>
+        )}
+
+        {/* 이미지 추가 세션 */}
+        <div className={'flex gap-x-2 '}>
+          <div className={'rounded-[8px] p-2 bg-gray0 w-fit'}>
+            <label htmlFor="image">
+              <AddImageIcon />
+            </label>
+            <input
+              type={'file'}
+              accept={'image/*'}
+              id="image"
+              name="image"
+              ref={imgRef}
+              onChange={saveImgFile}
+              multiple
+              style={{ display: 'none' }}></input>
+          </div>
+
+          <div className={'w-[375px] flex items-center overflow-x-scroll gap-x-3'}>
+            {/* API에서 받은 과거의 urls */}
+            {pastImageUrls.map((img, i) => {
+              return (
+                <div key={i} className={'relative rounded-[8px]'}>
+                  <ImageDeleteButton i={i} type={'과거 이미지 URL'} usage={'edit'} />
+                  <div className={'relative rounded-[8px] w-[80px] h-[80px] overflow-hidden'}>
+                    <Image key={i} src={img} fill alt={img} className={'object-cover'}></Image>;
+                  </div>
+                </div>
+              );
+            })}
+
+            {/* 현재 추가된 urls */}
+            {imagePreviews.map((img, i) => {
+              return (
+                <div key={i} className={'relative rounded-[8px]'}>
+                  <ImageDeleteButton i={i} type={'현재 이미지 URL'} usage={'edit'} />
+                  <div className={'relative rounded-[8px] w-[80px] h-[80px] overflow-hidden'}>
+                    <Image key={i} src={img} fill alt={img} className={'object-cover'}></Image>;
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+};
+export default EditPost;
+
+function AddImageIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg width={34} height={30} fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        d="M3.139 29.528c-.663 0-1.217-.224-1.664-.67-.446-.447-.67-1.001-.67-1.664V9.584c0-.667.224-1.223.67-1.667.447-.445 1.001-.667 1.664-.667h5l3.083-3.389h8.528v1h-8.083L8.583 8.25H3.14c-.389 0-.708.13-.958.389a1.31 1.31 0 00-.375.944v17.611c0 .39.125.709.375.959s.569.375.958.375h24.333c.39 0 .708-.125.958-.375s.375-.57.375-.959V13.917h1v13.277c0 .663-.222 1.217-.666 1.664-.445.446-1 .67-1.667.67H3.14zM28.805 8.25V4.86h-3.388v-1h3.388V.472h1v3.389h3.39v1h-3.39V8.25h-1zm-13.5 15.889c1.62 0 2.984-.553 4.09-1.66 1.107-1.106 1.66-2.47 1.66-4.09 0-1.62-.553-2.984-1.66-4.09-1.106-1.107-2.47-1.66-4.09-1.66-1.62 0-2.983.553-4.09 1.66-1.106 1.106-1.66 2.47-1.66 4.09 0 1.62.554 2.984 1.66 4.09 1.107 1.107 2.47 1.66 4.09 1.66zm0-1c-1.351 0-2.48-.454-3.388-1.361-.908-.908-1.361-2.037-1.361-3.39 0-1.351.453-2.48 1.36-3.388.908-.908 2.038-1.361 3.39-1.361 1.351 0 2.481.454 3.388 1.36.908.908 1.361 2.038 1.361 3.39 0 1.352-.453 2.481-1.36 3.389-.908.907-2.038 1.36-3.39 1.36z"
+        fill="#1C1B1F"
+      />
+    </svg>
+  );
+}
+function DropDownIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg width={20} height={20} fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d="M13.5 8.5l-3.5 3-3.5-3" stroke="#000" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function DropUpIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg width={20} height={20} fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d="M6.5 11.5l3.5-3 3.5 3" stroke="#000" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/src/components/community/ImageDeleteButton.tsx
+++ b/src/components/community/ImageDeleteButton.tsx
@@ -3,22 +3,54 @@
 import React, { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 
-import { deleteUrls,imagePreviewsState, imageUrlListState } from '@/recoil/community/atom';
+import { editPostDataState, imagePreviewsState, imageUrlListState, pastImageUrlsState } from '@/recoil/community/atom';
 
 interface Props {
-  usage: string;
+  usage: string; //create(글생성), edit(글수정)
+  type?: string;
   //imgFiles(현재)과 imageUrls(과거)의 인덱스
   i: number;
-  //imgFiles에서 사용되는지, imageUrls에서 사용되는지 판별
-  type?: string;
 }
 const ImageDeleteButton = (props: Props) => {
   const { usage, i, type } = props;
-  const [imagePreviews, setImagePreviews] = useRecoilState<string[]>(imagePreviewsState);// 파일 업로드
+  const [imagePreviews, setImagePreviews] = useRecoilState<string[]>(imagePreviewsState); // 파일 업로드
   const [imageUrlList, setImageUrlList] = useRecoilState<File[]>(imageUrlListState);
+  const [pastImageUrls, setPastImageUrls] = useRecoilState<string[]>(pastImageUrlsState);
+  const [editPostData, setEditPostData] = useRecoilState(editPostDataState);
+
+  //수정글에서(usage==edit) 미리보기에서 X버튼 클릭했을 때 삭제되도록 하는 함수
+  const deletePreviewImage = () => {
+    const copyImagePreviews = [...imagePreviews]; // 미리보기 imageUrl
+    const copyImageUrlList = [...imageUrlList]; // formData를 세팅할 fileList
+    const copyPastImageUrls = [...pastImageUrls]; // 과거에서 삭제할 경우
+
+    //과거 이미지 url 리스트에서 해당 목록 삭제
+    if (type === '과거 이미지 URL') {
+      setPastImageUrls(copyPastImageUrls.filter((imageUrl) => imageUrl != pastImageUrls[i]));
+    }
+
+    //현재 이미지 url 리스트에서 해당 목록 삭제
+    if (type === '현재 이미지 URL') {
+      setImagePreviews(copyImagePreviews.filter((imageUrl) => imageUrl != imagePreviews[i]));
+      setImageUrlList(copyImageUrlList.filter((file) => file != imageUrlList[i]));
+    }
+  };
 
   /**
-   * 선택된 imageUrl 을 제외하고 남은 imageUrl 로 새로운 리스트를 구성합니다.
+   * 수정글에서(usage==edit) 진짜 삭제할 수 있도록 deleteImageUrls 리스트에 삭제할 url 을 추가하는 함수
+   */
+  const deleteImageData = () => {
+    const copy = [...editPostData.removeImageUrls];
+    const copyPastImageUrls = [...pastImageUrls];
+
+    if (type === '과거 이미지 URL' && !copy.includes(copyPastImageUrls[i])) {
+      copy.push(copyPastImageUrls[i]);
+      setEditPostData((prevState) => ({ ...prevState, removeImageUrls: copy }));
+    }
+  };
+
+  /**
+   * 글을 새로 생성할 때(usage==create), 선택된 imageUrl 을 제외하고 남은 imageUrl 로 새로운 리스트를 구성합니다.
    */
   const deleteImageUrl = () => {
     const copyImageUrlList = [...imageUrlList]; // 과거에서 삭제할 경우
@@ -33,7 +65,13 @@ const ImageDeleteButton = (props: Props) => {
         className="absolute bg-red-600 rounded-full p-1 top-0 right-0 z-10"
         type={'button'}
         onClick={() => {
-          deleteImageUrl();
+          if (usage === 'edit') {
+            deletePreviewImage();
+            deleteImageData();
+          }
+          if (usage === 'create') {
+            deleteImageUrl();
+          }
         }}>
         <div className={'absolute top-0 right-0 bg-gray3 rounded-full p-[5px] w-fit'}>
           <DeleteIcon />
@@ -58,4 +96,3 @@ function DeleteIcon(props: React.SVGProps<SVGSVGElement>) {
     </svg>
   );
 }
-

--- a/src/components/community/WriteExplanationPost.tsx
+++ b/src/components/community/WriteExplanationPost.tsx
@@ -5,18 +5,18 @@ import FilterModal from '@/components/common/FilterModal';
 import MockExamYearsFilter from '@/components/common/MockExamYearsFilter';
 import useGetMockExamYearsAndRounds from '@/lib/hooks/useGetMockExamYearsAndRounds';
 import { useRecoilState } from 'recoil';
-import { imagePreviewsState, imageUrlListState, postDataState } from '@/recoil/community/atom';
+import { imagePreviewsState, imageUrlListState, createPostDataState } from '@/recoil/community/atom';
 import { postCommentary } from '@/lib/api/community';
 import ImageDeleteButton from '@/components/community/ImageDeleteButton';
 import useMockExamQuestions from '@/lib/hooks/useMockExamQuestions';
 
 const WriteExplanationPost = () => {
   const { examYearWithRounds } = useGetMockExamYearsAndRounds();
-  const {questions} = useMockExamQuestions();
+  const { questions } = useMockExamQuestions();
   const [isYearsFilterOpen, setIsYearsFilterOpen] = useState(false);
   const [isRoundsFilterOpen, setIsRoundsFilterOpen] = useState(false);
 
-  const [postData, setPostData] = useRecoilState(postDataState);
+  const [postData, setPostData] = useRecoilState(createPostDataState);
   const [imagePreviews, setImagePreviews] = useRecoilState<string[]>(imagePreviewsState);
   const [imageUrlList, setImageUrlList] = useRecoilState<File[]>(imageUrlListState);
   const imgRef = useRef<HTMLInputElement>(null);
@@ -231,7 +231,7 @@ const WriteExplanationPost = () => {
             {imagePreviews.map((img, i) => {
               return (
                 <div key={i} className={'relative rounded-[8px]'}>
-                  <ImageDeleteButton i={i} usage={'POST'} />
+                  <ImageDeleteButton i={i} usage={'create'} />
                   <div className={'relative rounded-[8px] w-[80px] h-[80px] overflow-hidden'}>
                     <Image key={i} src={img} fill alt={img} className={'object-cover'}></Image>;
                   </div>

--- a/src/components/community/WriteNormalPost.tsx
+++ b/src/components/community/WriteNormalPost.tsx
@@ -6,10 +6,10 @@ import { useRecoilState } from 'recoil';
 
 import ImageDeleteButton from '@/components/community/ImageDeleteButton';
 import { postCommentary } from '@/lib/api/community';
-import { imagePreviewsState, imageUrlListState, postDataState } from '@/recoil/community/atom';
+import { imagePreviewsState, imageUrlListState, createPostDataState } from '@/recoil/community/atom';
 
 const WriteNormalPost = () => {
-  const [postData, setPostData] = useRecoilState(postDataState);
+  const [postData, setPostData] = useRecoilState(createPostDataState);
   const [imagePreviews, setImagePreviews] = useRecoilState<string[]>(imagePreviewsState);
   const [imageUrlList, setImageUrlList] = useRecoilState<File[]>(imageUrlListState);
   const imgRef = useRef<HTMLInputElement>(null);
@@ -130,7 +130,7 @@ const WriteNormalPost = () => {
             {imagePreviews.map((img, i) => {
               return (
                 <div key={i} className={'relative rounded-[8px]'}>
-                  <ImageDeleteButton i={i} usage={'POST'} />
+                  <ImageDeleteButton i={i} usage={'create'} />
                   <div className={'relative rounded-[8px] w-[80px] h-[80px] overflow-hidden'}>
                     <Image key={i} src={img} fill alt={img} className={'object-cover'}></Image>;
                   </div>

--- a/src/components/community/WriteTipPost.tsx
+++ b/src/components/community/WriteTipPost.tsx
@@ -6,10 +6,10 @@ import { useRecoilState } from 'recoil';
 
 import ImageDeleteButton from '@/components/community/ImageDeleteButton';
 import { postCommentary } from '@/lib/api/community';
-import { imagePreviewsState, imageUrlListState, postDataState } from '@/recoil/community/atom';
+import { imagePreviewsState, imageUrlListState, createPostDataState } from '@/recoil/community/atom';
 
 const WriteTipPost = () => {
-  const [postData, setPostData] = useRecoilState(postDataState);
+  const [postData, setPostData] = useRecoilState(createPostDataState);
   const [imagePreviews, setImagePreviews] = useRecoilState<string[]>(imagePreviewsState);
   const [imageUrlList, setImageUrlList] = useRecoilState<File[]>(imageUrlListState);
   const imgRef = useRef<HTMLInputElement>(null);
@@ -275,7 +275,7 @@ const WriteTipPost = () => {
             {imagePreviews.map((img, i) => {
               return (
                 <div key={i} className={'relative rounded-[8px]'}>
-                  <ImageDeleteButton i={i} usage={'POST'} />
+                  <ImageDeleteButton i={i} usage={'create'} />
                   <div className={'relative rounded-[8px] w-[80px] h-[80px] overflow-hidden'}>
                     <Image key={i} src={img} fill alt={img} className={'object-cover'}></Image>;
                   </div>

--- a/src/lib/api/community.ts
+++ b/src/lib/api/community.ts
@@ -1,6 +1,6 @@
 import { sendRequest } from '../axios';
 import { post } from 'axios';
-import { PostDataType } from '@/types/community/type';
+import { CreatePostDataType } from '@/types/community/type';
 
 export const postFavoriteBoards = async (certificateId: number) => {
   try {
@@ -32,6 +32,28 @@ export const postCommentary = async (certificateId: number, postType: string, fo
       data: formData,
       url: `/certificates/${certificateId}/${postType}/posts`,
     });
+    console.log(response.data);
+    // 성공적인 응답 처리
+    return response.data;
+  } catch (error) {
+    // 에러 처리
+    console.error('에러 발생:', error);
+  }
+};
+
+export const putPostDetail = async (certificateId: number, postType: string, formData: FormData) => {
+  try {
+    // 액세스 토큰을 헤더에 담아 요청 보내기
+    const response = await sendRequest({
+      headers: {
+        'Access-Token': localStorage.getItem('accessToken'),
+        'Content-Type': 'multipart/form-data',
+      },
+      method: 'PUT',
+      data: formData,
+      url: `/certificates/${certificateId}/${postType}/posts`,
+    });
+    console.log(response.data);
     // 성공적인 응답 처리
     return response.data;
   } catch (error) {

--- a/src/lib/hooks/useGetPost.tsx
+++ b/src/lib/hooks/useGetPost.tsx
@@ -1,0 +1,16 @@
+import { AxiosResponse } from 'axios';
+import useSWR from 'swr';
+
+import { swrGetFetcher } from '@/lib/axios';
+import { userProfile } from '@/types/global';
+
+const useGetPost = () => {
+  //66: 자유, 61: 해설, 55: 꿀팁
+  const { data, error } = useSWR<AxiosResponse<userProfile>>('/posts/55', swrGetFetcher);
+  return {
+    postDetailData: data ? data.result : null,
+    isLoading: !error && !data,
+    isError: error,
+  };
+};
+export default useGetPost;

--- a/src/recoil/community/atom.ts
+++ b/src/recoil/community/atom.ts
@@ -5,7 +5,7 @@ import { atom } from 'recoil';
 import { SubjectResultRequests, UserAnswerRequests } from '@/types/global';
 import { extend } from 'dayjs';
 import SubjectList from '@/components/exam/SubjectList';
-import { PostDataType } from '@/types/community/type';
+import { CreatePostDataType, EditPostDataType } from '@/types/community/type';
 
 export const imagePreviewsState = atom<string[]>({
   key: 'imagePreviewsState',
@@ -17,8 +17,13 @@ export const imageUrlListState = atom<File[]>({
   default: [],
 });
 
-export const postDataState = atom<PostDataType>({
-  key: 'postDataState',
+export const pastImageUrlsState = atom<string[]>({
+  key: 'pastImageUrlsState',
+  default: [],
+});
+
+export const createPostDataState = atom<CreatePostDataType>({
+  key: 'createPostDataState',
   default: {
     title: '제목',
     content: '내용',
@@ -26,5 +31,14 @@ export const postDataState = atom<PostDataType>({
     examYear: 2023,
     round: 1,
     questionSequence: 0,
+  },
+});
+
+export const editPostDataState = atom<EditPostDataType>({
+  key: 'editPostDataState',
+  default: {
+    postId: 0,
+    title: '제목',
+    content: '내용',
   },
 });

--- a/src/types/community/type.ts
+++ b/src/types/community/type.ts
@@ -8,15 +8,26 @@ export interface YearsAndRounds {
   2023: number[];
 }
 
-export interface PostDataType {
+export interface CreatePostDataType {
   title: string;
   content: string;
   tags?: TipPostTagType[];
-  examYear: number;
-  round: number;
+  examYear?: number;
+  round?: number;
   questionSequence?: number;
 }
-interface TipPostTagType {
+export interface TipPostTagType {
   tagType: string;
   tagName: string;
+}
+
+export interface EditPostDataType {
+  postId: number;
+  title: string;
+  content: string;
+  newTags?: TipPostTagType[];
+  examYear?: number;
+  round?: number;
+  questionSequence?: number;
+  removeImageUrls?: string[];
 }


### PR DESCRIPTION
Closes #68 

<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

- api에 postId를 넣어서 데이터를 불러오면 해설 게시글, 자유 게시글, 꿀팁 게시글에 따라서 ui을 다르게 보이도록 구현하였습니다.
- 해설 게시글, 자유 게시글, 꿀팁 게시글에 따라서 put요청을 다르게 지정하였습니다.
- 3개의 게시글이 따로따로 잘 동작될 수 있도록 코드를 손봤습니다.

## ✅ PR Point

- 기존의 방식은 하나의 컴포넌트로 값이 다르게 들어옴에 따라 ui만 바뀌게 설계되어있는데(api를 가져올 때 게시판으로 카테고리로 게시글을 가져올 수 있는게 아니라, postId를 주면 게시글을 받을 수 있기 때문에 종류를 알지 못하는줄 알고 이렇게 했다가 다 만들고 대충 이렇게 하면 더 좋았겠다 하는 생각이 들어,.), 아예 3개의 컴포넌트로 해설글 수정, 자유게시글 수정, 꿀팁글 수정을 보이는게 좋았겠다는 생각이 들어서 추후 시간이 되면 수정해보려고 합니다.. 

## 😭 어려웠던 점

- 해설 게시글에 번호를 입력하는 부분에서 value값으로 questionSeq를 넣고 event를 감지해서 비어있으면 비어있다 뜨고 싶은데,
value값이 채워있음에도 불구하고 비어있다고 뜨고, 해결하니까 비어있는데도 경고문을 안줘서 삽질을 좀 했습니다.
-> 얘도 비동기 문제가 있어서 useEffect로 처리했습니다.
