### PR TITLE
[#74][REFACTOR] header에 headerType 추가

### DIFF
--- a/src/app/(main)/exam/page.tsx
+++ b/src/app/(main)/exam/page.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import Header from '@/components/common/Header';
 import NavBar from '@/components/common/NavBar';
-import SubjectSessionCard from '@/components/exam/SubjectList';
 import WrongQuestionsSummaryBox from '@/components/exam/IncorrectQuestionSummaryCard';
+import SubjectSessionCard from '@/components/exam/SubjectList';
 import YearSelector from '@/components/exam/YearSelector';
 
 const Exam = () => {

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,10 +1,42 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
-export default function Header() {
+import { HeaderType } from '@/types/global';
+
+interface Props {
+  headerType?: HeaderType;
+  title?: string;
+  rightElement?: ReactNode;
+}
+
+export default function Header(props: Props) {
+  const { headerType = 'static', title, rightElement } = props;
+
+  const renderHeader = (headerType: HeaderType) => {
+    switch (headerType) {
+      case 'static':
+        return (
+          <>
+            <Logo />
+            <AlarmIcon />
+          </>
+        );
+      case 'dynamic':
+        return (
+          <>
+            <PrevArrow />
+            <h1 className="text-black font-h1">{title}</h1>
+            {rightElement ? { rightElement } : <div />}
+          </>
+        );
+
+      default:
+        break;
+    }
+  };
+
   return (
-    <header className="flex justify-between items-center px-[1.25rem] py-[0.25rem]">
-      <Logo />
-      <AlarmIcon />
+    <header className="flex sticky top-0 justify-between items-center px-[1.25rem] py-[0.25rem]">
+      {renderHeader(headerType)}
     </header>
   );
 }
@@ -31,3 +63,9 @@ function AlarmIcon(props: React.SVGProps<SVGSVGElement>) {
     </svg>
   );
 }
+
+const PrevArrow = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={33} height={32} fill="none" {...props}>
+    <path stroke="#0D0E10" strokeLinecap="round" strokeLinejoin="round" d="m21.646 26-10-10 10-10" />
+  </svg>
+);

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,5 +1,7 @@
 import React from 'react';
 
+export type HeaderType = 'static' | 'dynamic';
+
 export interface MenuList {
   id: number;
   Icon: (props: React.SVGProps<SVGSVGElement>) => JSX.Element;


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

Closes #74 

## ✨ 구현 기능 명세

- 기존의 header 컴포넌트에 타입을 지정할 수 있는 `headerType` 이라는 타입을 추가했습니다,

   
```tsx
export type HeaderType = 'static' | 'dynamic';
```

- `<Header />`의 prop으로 headerType을 적어서 사용 해 주시면 되며, 모든 타입은 optional이며, `headerType`의 기본 값은 `'static'`입니다.

```tsx
interface Props {
  headerType?: HeaderType;
  title?: string;
  rightElement?: ReactNode;
}

export default function Header(props: Props) {
  const { headerType = 'static', title, rightElement } = props;

  const renderHeader = (headerType: HeaderType) => {
    switch (headerType) {
      case 'static':
        return (
          <>
            <Logo />
            <AlarmIcon />
          </>
        );
      case 'dynamic':
        return (
          <>
            <PrevArrow />
            <h1 className="text-black font-h1">{title}</h1>
            {rightElement ? { rightElement } : <div />}
          </>
        );

      default:
        break;
    }
  };

  return (
    <header className="flex sticky top-0 justify-between items-center px-[1.25rem] py-[0.25rem]">
      {renderHeader(headerType)}
    </header>
  );
}
```


<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

## ✅ PR Point

- 아직 추가적인 스타일링 작업이 필요합니다.

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
