### PR TITLE
[#87] 마이페이지 프로필 수정 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-beautiful-dnd": "^13.1.1",
         "react-dom": "latest",
         "react-icons": "^5.0.1",
+        "react-intersection-observer": "^9.8.2",
         "react-responsive-carousel": "^3.2.23",
         "react-router-dom": "^6.21.1",
         "react-slick": "^0.30.2",
@@ -4650,6 +4651,20 @@
       "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
       "peerDependencies": {
         "react": "*"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.8.2.tgz",
+      "integrity": "sha512-901naEiiZmse3p+AmtbQ3NL9xx+gQ8TXLiGDc+8GiE3JKJkNV3vP737aGuWTAXBA+1QqxPrDDE+fIEgYpGDlrQ==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-icons": "^5.0.1",
         "react-intersection-observer": "^9.8.2",
         "react-responsive-carousel": "^3.2.23",
-        "react-router-dom": "^6.21.1",
+        "react-router-dom": "^6.22.3",
         "react-slick": "^0.30.2",
         "recharts": "^2.10.4",
         "recoil": "^0.7.7",
@@ -606,9 +606,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.14.1.tgz",
-      "integrity": "sha512-Qg4DMQsfPNAs88rb2xkdk03N3bjK4jgX5fR24eHCTR9q6PrhZQZ4UJBPzCHJkIpTRN1UKxx2DzjZmnC+7Lj0Ow==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
+      "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -4717,11 +4717,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.21.1.tgz",
-      "integrity": "sha512-W0l13YlMTm1YrpVIOpjCADJqEUpz1vm+CMo47RuFX4Ftegwm6KOYsL5G3eiE52jnJpKvzm6uB/vTKTPKM8dmkA==",
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.3.tgz",
+      "integrity": "sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==",
       "dependencies": {
-        "@remix-run/router": "1.14.1"
+        "@remix-run/router": "1.15.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -4731,12 +4731,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.21.1.tgz",
-      "integrity": "sha512-QCNrtjtDPwHDO+AO21MJd7yIcr41UetYt5jzaB9Y1UYaPTCnVuJq6S748g1dE11OQlCFIQg+RtAA1SEZIyiBeA==",
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.3.tgz",
+      "integrity": "sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==",
       "dependencies": {
-        "@remix-run/router": "1.14.1",
-        "react-router": "6.21.1"
+        "@remix-run/router": "1.15.3",
+        "react-router": "6.22.3"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "latest",
     "react-icons": "^5.0.1",
+    "react-intersection-observer": "^9.8.2",
     "react-responsive-carousel": "^3.2.23",
     "react-router-dom": "^6.21.1",
     "react-slick": "^0.30.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-icons": "^5.0.1",
     "react-intersection-observer": "^9.8.2",
     "react-responsive-carousel": "^3.2.23",
-    "react-router-dom": "^6.21.1",
+    "react-router-dom": "^6.22.3",
     "react-slick": "^0.30.2",
     "recharts": "^2.10.4",
     "recoil": "^0.7.7",

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -6,7 +6,7 @@ import NavBar from '@/components/common/NavBar';
 export default function layout({ children }: { children: React.ReactNode }) {
   return (
     <>
-      <Header />
+      {/* <Header /> */}
       <div>
         {children}
         {/*<Link href="/">온보딩 화면으로 아동하기</Link>*/}

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -11,7 +11,7 @@ export default function layout({ children }: { children: React.ReactNode }) {
         {children}
         {/*<Link href="/">온보딩 화면으로 아동하기</Link>*/}
       </div>
-      <NavBar />
+      {/*<NavBar />*/}
     </>
   );
 }

--- a/src/app/(main)/mypage/myComment/page.tsx
+++ b/src/app/(main)/mypage/myComment/page.tsx
@@ -1,0 +1,50 @@
+import NavBar from '@/components/common/NavBar';
+
+export default function MyComment() {
+  return (
+    <>
+      <div className="w-full mt-2">
+        <header className="flex justify-between items-center px-[1.25rem] py-[0.25rem] text-h4">
+          <a href="../mypage">{'<'}</a>
+          <div>내가 쓴 댓글</div>
+          <div>...</div>
+        </header>
+      </div>
+
+      <div className="w-full bg-gray1 mt-3 px-3 py-3 min-h-screen">
+        <select className="rounded-2xl text-h6 text-gray4">
+          <option key="all" value="all">
+            전체
+          </option>
+          <option key="new" value="new">
+            최신순
+          </option>
+          <option key="old" value="old">
+            작성순
+          </option>
+        </select>
+        {/* 여기가 박스안에 내용들 담아놓은곳 아래.. */}
+        <div className="w-full bg-white rounded-2xl mt-3 py-2">
+          <div className="flex justify-between px-3 py-[0.25rem]">
+            <div className="text-h6 ml-3">nickname</div>
+            <div className="flex justify-between">
+              <div className="rounded-2xl text-h6 border border-gray4 py-[2px] px-1 text-gray4 mx-2">
+                준비기간 6개월 ↑
+              </div>
+              <div className="rounded-2xl text-h6 text-white bg-point py-[2px] px-1">조금 어려워요</div>
+            </div>
+          </div>
+          <div>
+            <div className="px-6 mt-2">
+              <div className="text-h3">여기에는 제목이 들어갈거고</div>
+              <div className="text-h6 text-black">여기에는 내용이 들어갈거고</div>
+              <div className="text-h7"> 여기에 좋아요랑 댓글 수가 들어갈거고.</div>
+              <div className="text-gray4 text-h7">작성일 2024.03.16</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <NavBar />
+    </>
+  );
+}

--- a/src/app/(main)/mypage/myWriting/page.tsx
+++ b/src/app/(main)/mypage/myWriting/page.tsx
@@ -5,9 +5,9 @@ export default function MyWriting() {
     <>
       <div className="w-full mt-2">
         <header className="flex justify-between items-center px-[1.25rem] py-[0.25rem] text-h4">
-          <button>{'<'}</button>
+          <a href="../mypage">{'<'}</a>
           <div>내가 쓴 글</div>
-          <button>검색</button>
+          <div>...</div>
         </header>
         <div className="flex justify-around mt-2">
           <button className="rounded-2xl border border-gray2 px-3 py-1 text-h6 focus:bg-black focus:text-white mx-1">

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -7,6 +7,7 @@ import { useRecoilState } from 'recoil';
 import { userProfile } from '@/types/global';
 import useGetUserProfile from '@/lib/hooks/useGetUserProfile';
 import NavBar from '@/components/common/NavBar';
+import Header from '@/components/common/Header';
 
 export default function MyPage() {
   const { userProfile, isLoading, isError } = useGetUserProfile();
@@ -25,70 +26,82 @@ export default function MyPage() {
 
   return (
     <>
-      <div className="w-full flex justify-start items-center mx-2">
-        <img
-          src={userProfile ? userProfile.profileImage : '없'}
-          className="w-16 h-16 bg-gray4 object-cover rounded-full"
-        />
-        <span className="text-h4 ml-3">
-          {userProfile ? userProfile.nickname : '없지롱'}
-          {/*프로필 설정화면으로 이동*/}
-          <a href="mypage/profileSetting">{'>'}</a>
-        </span>
-      </div>
-      <div className="w-full mt-3 flex justify-between mx-2">
-        <div className="font-bold">나의 관심 종목</div>
-        <button className="text-h6 text-gray3">변경 {'>'}</button>
-      </div>
-      <div className="w-full flex justify-between mt-3 mx-2 overflow-hidden">
-        <div className="px-3 py-4 rounded-lg text-white text-h7 bg-primary">컴퓨터 활용능력 2급</div>
-        <div className="px-3 py-4 rounded-lg text-white text-h7 bg-primary">컴퓨터 활용능력 2급</div>
-        <div className="px-3 py-4 rounded-lg text-white text-h7 bg-primary">컴퓨터 활용능력 2급</div>
-      </div>
-      {/* 전체적인 틀 */}
-      <div className="w-full bg-gray1  mx-2 mt-3 px-3 py-3">
-        {/* 게시판 */}
-        <div className="w-full bg-white rounded-md mt-3 py-3">
-          <div className="text-h6 px-2">게시판</div>
-          <button className="w-[95%] flex justify-between text-h6 mx-2 mt-2 px-2 py-3 rounded-lg bg-gray0 text-gray4">
-            내가 작성한 글<div>{'>'}</div>
-          </button>
-          <button className="w-[95%] flex justify-between text-h6 mx-2 mt-2 px-2 py-3 rounded-lg bg-gray0 text-gray4">
-            내가 작성한 댓글<div>{'>'}</div>
-          </button>
+      {userProfile === null ? (
+        <div>로그인이나 하고오세요~</div>
+      ) : (
+        <div>
+          <Header />
+          <div className="w-full flex justify-start items-center mx-2">
+            <img
+              src={userProfile ? userProfile.profileImage : '없'}
+              className="w-16 h-16 bg-gray4 object-cover rounded-full"
+            />
+            <span className="text-h4 ml-3">
+              {userProfile ? userProfile.nickname : '없지롱'}
+              {/*프로필 설정화면으로 이동*/}
+              <a href="mypage/profileSetting">{'>'}</a>
+            </span>
+          </div>
+          <div className="w-full mt-3 flex justify-between mx-2">
+            <div className="font-bold">나의 관심 종목</div>
+            <button className="text-h6 text-gray3">변경 {'>'}</button>
+          </div>
+          <div className="w-full flex justify-between mt-3 mx-2 overflow-hidden">
+            <div className="px-3 py-4 rounded-lg text-white text-h7 bg-primary">컴퓨터 활용능력 2급</div>
+            <div className="px-3 py-4 rounded-lg text-white text-h7 bg-primary">컴퓨터 활용능력 2급</div>
+            <div className="px-3 py-4 rounded-lg text-white text-h7 bg-primary">컴퓨터 활용능력 2급</div>
+          </div>
+          {/* 전체적인 틀 */}
+          <div className="w-full bg-gray1  mx-2 mt-3 px-3 py-3">
+            {/* 게시판 */}
+            <div className="w-full bg-white rounded-md mt-3 py-3">
+              <div className="text-h6 px-2">게시판</div>
+              <a
+                href="mypage/myWriting"
+                className="w-[95%] flex justify-between text-h6 mx-2 mt-2 px-2 py-3 rounded-lg bg-gray0 text-gray4">
+                내가 작성한 글<div>{'>'}</div>
+              </a>
+              {/* 위 아래를 들어가려면 먼저 로그인이 되어있는지 확인해야 합니다. */}
+              <a
+                href="mypage/myComment"
+                className="w-[95%] flex justify-between text-h6 mx-2 mt-2 px-2 py-3 rounded-lg bg-gray0 text-gray4">
+                내가 작성한 댓글<div>{'>'}</div>
+              </a>
+            </div>
+            {/* 알림설정 */}
+            <div className="w-full bg-white rounded-md mt-3 py-3">
+              <div className="text-h6 px-2">설정</div>
+              <button className="w-[95%] flex justify-between text-h6 mx-2 mt-2 px-2 py-3 rounded-lg bg-gray0 text-gray4">
+                알림설정 <div>{'>'}</div>
+              </button>
+            </div>
+            {/* 계정관리 */}
+            <div className="w-full bg-white rounded-md mt-3 py-3">
+              <div className="text-h6 px-2">계정관리</div>
+              <button className="w-[95%] flex justify-between text-h6 mx-2 mt-2 px-2 py-3 rounded-lg bg-gray0 text-gray4">
+                로그아웃 <div>{'>'}</div>
+              </button>
+              <button className="w-[95%] flex justify-between text-h6 mx-2 mt-2 px-2 py-3 rounded-lg bg-gray0 text-gray4">
+                탈퇴하기 <div>{'>'}</div>
+              </button>
+            </div>
+            {/* 기타 */}
+            <div className="w-full bg-white rounded-md mt-3 py-3">
+              <div className="text-h6 px-2">기타</div>
+              <button className="w-[95%] flex justify-between text-h6 mx-2 mt-2 px-2 py-3 rounded-lg bg-gray0 text-gray4">
+                문의하기 <div>{'>'}</div>
+              </button>
+              <button className="w-[95%] flex justify-between text-h6 mx-2 mt-2 px-2 py-3 rounded-lg bg-gray0 text-gray4">
+                약관 및 개인정보 처리 <div>{'>'}</div>
+              </button>
+              <button className="w-[95%] flex justify-between text-h6 mx-2 mt-2 px-2 py-3 rounded-lg bg-gray0 text-gray4">
+                앱버전 <div>{'1.1.23.1'}</div>
+              </button>
+            </div>
+          </div>
+          <NavBar />
         </div>
-        {/* 알림설정 */}
-        <div className="w-full bg-white rounded-md mt-3 py-3">
-          <div className="text-h6 px-2">설정</div>
-          <button className="w-[95%] flex justify-between text-h6 mx-2 mt-2 px-2 py-3 rounded-lg bg-gray0 text-gray4">
-            알림설정 <div>{'>'}</div>
-          </button>
-        </div>
-        {/* 계정관리 */}
-        <div className="w-full bg-white rounded-md mt-3 py-3">
-          <div className="text-h6 px-2">계정관리</div>
-          <button className="w-[95%] flex justify-between text-h6 mx-2 mt-2 px-2 py-3 rounded-lg bg-gray0 text-gray4">
-            로그아웃 <div>{'>'}</div>
-          </button>
-          <button className="w-[95%] flex justify-between text-h6 mx-2 mt-2 px-2 py-3 rounded-lg bg-gray0 text-gray4">
-            탈퇴하기 <div>{'>'}</div>
-          </button>
-        </div>
-        {/* 기타 */}
-        <div className="w-full bg-white rounded-md mt-3 py-3">
-          <div className="text-h6 px-2">기타</div>
-          <button className="w-[95%] flex justify-between text-h6 mx-2 mt-2 px-2 py-3 rounded-lg bg-gray0 text-gray4">
-            문의하기 <div>{'>'}</div>
-          </button>
-          <button className="w-[95%] flex justify-between text-h6 mx-2 mt-2 px-2 py-3 rounded-lg bg-gray0 text-gray4">
-            약관 및 개인정보 처리 <div>{'>'}</div>
-          </button>
-          <button className="w-[95%] flex justify-between text-h6 mx-2 mt-2 px-2 py-3 rounded-lg bg-gray0 text-gray4">
-            앱버전 <div>{'1.1.23.1'}</div>
-          </button>
-        </div>
-      </div>
-      <NavBar />
+      )}
     </>
   );
 }

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -19,7 +19,7 @@ export default function MyPage() {
 
   useEffect(() => {
     if (userProfile) {
-      console.log('데이터는 들어온다1');
+      // console.log('데이터는 들어온다1'); <왜출력안되는거징
       getUserProfile();
     }
   }, []);
@@ -36,7 +36,8 @@ export default function MyPage() {
           className="w-16 h-16 bg-gray4 object-cover rounded-full"
         />
         <span className="text-h4 ml-3">
-          {userProfile ? userProfile.nickname : '없지롱'} {'>'}
+          {userProfile ? userProfile.nickname : '없지롱'}
+          <a href="mypage/profileSetting">{'>'}</a>
         </span>
       </div>
       <div className="w-full mt-3 flex justify-between mx-2">

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import React from 'react';
-import Header from '@/components/common/Header';
-import NavBar from '@/components/common/NavBar';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { userProfile } from '@/types/global';
 import useGetUserProfile from '@/lib/hooks/useGetUserProfile';
+import { certificationInfoState } from '@/recoil/home/atom';
 
 export default function MyPage() {
   const { userProfile, isLoading, isError } = useGetUserProfile();
@@ -26,10 +25,6 @@ export default function MyPage() {
 
   return (
     <>
-      <div className="w-full">
-        <Header />
-      </div>
-
       <div className="w-full flex justify-start items-center mx-2">
         <img
           src={userProfile ? userProfile.profileImage : '없'}
@@ -37,6 +32,7 @@ export default function MyPage() {
         />
         <span className="text-h4 ml-3">
           {userProfile ? userProfile.nickname : '없지롱'}
+          {/*프로필 설정화면으로 이동*/}
           <a href="mypage/profileSetting">{'>'}</a>
         </span>
       </div>
@@ -92,7 +88,6 @@ export default function MyPage() {
           </button>
         </div>
       </div>
-      <NavBar />
     </>
   );
 }

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { userProfile } from '@/types/global';
 import useGetUserProfile from '@/lib/hooks/useGetUserProfile';
-import { certificationInfoState } from '@/recoil/home/atom';
+import NavBar from '@/components/common/NavBar';
 
 export default function MyPage() {
   const { userProfile, isLoading, isError } = useGetUserProfile();
@@ -88,6 +88,7 @@ export default function MyPage() {
           </button>
         </div>
       </div>
+      <NavBar />
     </>
   );
 }

--- a/src/app/(main)/mypage/profileSetting/page.tsx
+++ b/src/app/(main)/mypage/profileSetting/page.tsx
@@ -1,54 +1,140 @@
 'use client';
-import React from 'react';
-import { useCallback, useEffect, useState } from 'react';
-import { useRecoilState } from 'recoil';
+import Image from 'next/image';
+import { FormEvent, useCallback, useEffect, useRef, useState } from 'react';
+
+import { patchProfileData } from '@/lib/api/onboarding';
 import useGetUserProfile from '@/lib/hooks/useGetUserProfile';
-import CommunityNav from '@/components/community/CommunityNav';
-import Button from '@/components/common/Button';
 
-export default function ProfileSetting() {
+interface Props {
+  onNext: () => void;
+  onBefore: () => void;
+}
+const ProfileSettings = (props: Props) => {
+  const { onNext, onBefore } = props;
   const { userProfile, isLoading, isError } = useGetUserProfile();
-  const [nickname, setNickname] = useState('');
-
-  //const handlerChangeId
+  const imgRef = useRef<HTMLInputElement>(null);
+  const [uploadImage, setUploadImage] = useState();
 
   // 모든 자격증 리스트 불러오는 함수
   const getUserProfile = useCallback(async () => {
     return userProfile;
   }, []);
 
+  // 이미지 미리보기 설정
+  const handleImagePreview = async () => {
+    const files = imgRef.current?.files;
+    let reader = new FileReader();
+    reader.readAsDataURL(files[0]);
+    reader.onloadend = () => {
+      setUploadImage(reader.result);
+    };
+  };
+
+  // 폼 제출 핸들러
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault(); // 폼 제출 시 새로고침 방지
+    const formData = new FormData();
+
+    formData.append('file', imgRef.current.files[0]); // 파일을 formData에 추가
+
+    const json = { nickname: e.target.nickname.value };
+    formData.append(
+      'request',
+      new Blob([JSON.stringify(json)], {
+        type: 'application/json',
+      }),
+    );
+
+    try {
+      const response = await patchProfileData(formData); // API 호출
+      onNext();
+    } catch (error) {
+      console.error('폼 제출 중 오류 발생:', error);
+    }
+  };
+
   useEffect(() => {
     if (userProfile) {
-      // console.log('데이터는 들어온다1'); <왜출력안되는거징
       getUserProfile();
     }
   }, []);
 
   return (
-    <>
-      <CommunityNav Icon={false}>프로필 변경</CommunityNav>
+    <div>
+      <form onSubmit={handleSubmit}>
+        <button onClick={onBefore}>이전</button>
+        <div className="flex flex-col gap-y-5 m-5">
+          {/* 프로필 사진 설정 섹션 */}
+          <div className="flex flex-col justify-center items-center">
+            <div className="relative w-fit">
+              <div className="relative w-[100px] h-[100px] object-cover overflow-hidden rounded-full">
+                <Image
+                  alt={userProfile ? userProfile.userId : 0}
+                  src={
+                    uploadImage ? uploadImage : userProfile?.profileImage ? userProfile?.profileImage : '/person.png'
+                  }
+                  className={'object-cover'}
+                  fill></Image>
+              </div>
+              <label for="input-file">
+                <ProfileImageIcon className="absolute bottom-0 right-0" />
+              </label>
+              <input
+                type="file"
+                id={'input-file'}
+                ref={imgRef}
+                name="input-file"
+                onChange={handleImagePreview}
+                className="hidden"></input>
+            </div>
+          </div>
 
-      <div className=" bg-gray0">
-        <div className="flex justify-center">
-          <img
-            src={userProfile ? userProfile.profileImage : '없'}
-            className="w-16 h-16 bg-gray4 object-cover rounded-full"
-          />
-        </div>
-        <div className="flex justify-center">
-          <form>
-            <div className="mt-[30px] font-bold">닉네임</div>
+          {/* 닉네임 설정 섹션 */}
+          <div className={'flex flex-col gap-y-2'}>
+            <label className={'text-h3 font-bold'}>닉네임</label>
             <input
-              type="text"
-              className="rounded-xl px-2 py-1 bg-white font-bold placeholder-black placeholder"
-              placeholder={userProfile != null ? userProfile.nickname : '닉네임'}
-            />
-          </form>
+              className={'bg-neutral-100 rounded-[16px] py-3 px-4 placeholder:text-black focus:outline-none text-h4'}
+              id="nickname"
+              name="nickname"
+              defaultValue={userProfile ? userProfile.nickname : ''}></input>
+          </div>
         </div>
-        <button className="w-full px-2 py-2 rounded-t-2xl text-white bg-primary mt-10">완료</button>
-      </div>
 
-      {/*<Button>완료</Button>*/}
-    </>
+        <button
+          type={'submit'}
+          className={
+            'w-full bg-gray2 h-[100px] rounded-t-[32px] text-white text-h3 fixed bottom-0 hover:bg-primary transition'
+          }>
+          <div className="text-white text-h3 py-[25px]">완료</div>
+        </button>
+      </form>
+    </div>
+  );
+};
+export default ProfileSettings;
+
+function ProfileImageIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg width={35} height={35} fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <rect x={0.838} y={0.886} width={33.6} height={33.6} rx={16.8} fill="#9E9FA1" />
+      <mask
+        id="prefix__a"
+        style={{
+          maskType: 'alpha',
+        }}
+        maskUnits="userSpaceOnUse"
+        x={3}
+        y={3}
+        width={30}
+        height={30}>
+        <path fill="#D9D9D9" d="M3.237 3.286h28.8v28.8h-28.8z" />
+      </mask>
+      <g mask="url(#prefix__a)">
+        <path
+          d="M17.638 22.965c1.2 0 2.22-.42 3.06-1.26.84-.84 1.26-1.86 1.26-3.06s-.42-2.22-1.26-3.06c-.84-.84-1.86-1.26-3.06-1.26s-2.22.42-3.06 1.26c-.84.84-1.26 1.86-1.26 3.06s.42 2.22 1.26 3.06c.84.84 1.86 1.26 3.06 1.26zm0-1.92c-.672 0-1.24-.232-1.704-.696a2.317 2.317 0 01-.696-1.704c0-.672.232-1.24.696-1.704a2.317 2.317 0 011.704-.696c.672 0 1.24.232 1.704.696.464.464.696 1.032.696 1.704 0 .672-.232 1.24-.696 1.704a2.317 2.317 0 01-1.704.696zm-7.68 5.28c-.528 0-.98-.188-1.356-.564a1.849 1.849 0 01-.564-1.356v-11.52c0-.528.188-.98.564-1.356a1.849 1.849 0 011.356-.564h3.024l1.776-1.92h5.76l1.776 1.92h3.024c.528 0 .98.188 1.356.564.376.376.564.828.564 1.356v11.52c0 .528-.188.98-.564 1.356a1.849 1.849 0 01-1.356.564H9.958z"
+          fill="#fff"
+        />
+      </g>
+    </svg>
   );
 }

--- a/src/app/(main)/mypage/profileSetting/page.tsx
+++ b/src/app/(main)/mypage/profileSetting/page.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useCallback, useEffect, useRef, useState } from 'react';
 
 import { patchProfileData } from '@/lib/api/onboarding';
 import useGetUserProfile from '@/lib/hooks/useGetUserProfile';
+import Banner from '@/components/common/Banner';
 
 interface Props {
   onNext: () => void;
@@ -61,11 +62,18 @@ const ProfileSettings = (props: Props) => {
 
   return (
     <div>
-      <form onSubmit={handleSubmit}>
-        <button onClick={onBefore}>이전</button>
+      <header className="flex justify-between items-end px-[1.25rem] py-[0.25rem] text-h4 mt-2">
+        <button onClick={onBefore} className="text-h2">
+          {'<'}
+        </button>
+        <div>내가 쓴 댓글</div>
+        <div>...</div> {/* 얘가 없으면 정렬이 안돼... */}
+      </header>
+      <form onSubmit={handleSubmit} className="bg-gray0 min-h-screen">
+        <div className="w-full mt-2"></div>
         <div className="flex flex-col gap-y-5 m-5">
           {/* 프로필 사진 설정 섹션 */}
-          <div className="flex flex-col justify-center items-center">
+          <div className="flex flex-col justify-center items-center mt-5">
             <div className="relative w-fit">
               <div className="relative w-[100px] h-[100px] object-cover overflow-hidden rounded-full">
                 <Image

--- a/src/app/(main)/mypage/profileSetting/page.tsx
+++ b/src/app/(main)/mypage/profileSetting/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+import React from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import useGetUserProfile from '@/lib/hooks/useGetUserProfile';
+
+export default function ProfileSetting() {
+  const { userProfile, isLoading, isError } = useGetUserProfile();
+  const [id, setId] = useState('');
+  const [nickname, setNickname] = useState('');
+
+  //const handlerChangeId
+
+  // 모든 자격증 리스트 불러오는 함수
+  const getUserProfile = useCallback(async () => {
+    return userProfile;
+  }, []);
+
+  useEffect(() => {
+    if (userProfile) {
+      // console.log('데이터는 들어온다1'); <왜출력안되는거징
+      getUserProfile();
+    }
+  }, []);
+
+  return (
+    <>
+      <div className="w-full h-[60px] flex justify-center items-center py-3">
+        <div className="text-h4 font-bold">{'<'}</div>
+        <div className="text-h6"> 프로필 변경 </div>
+      </div>
+
+      <div className=" bg-gray0">
+        <div className="flex justify-center">
+          <img
+            src={userProfile ? userProfile.profileImage : '없'}
+            className="w-16 h-16 bg-gray4 object-cover rounded-full"
+          />
+          <button></button>
+        </div>
+        <form>
+          <div className="mt-[30px]">이름</div>
+          <input type="text" className="rounded-xl bg-white text-black font-bold" placeholder={userProfile.userId} />
+          <div className="mt-[30px]">닉네임</div>
+          <input type="text" className="rounded-xl bg-white text-black font-bold" placeholder={userProfile.nickname} />
+        </form>
+      </div>
+
+      <div className="border rounded-t-xl bg-primary font-bold text-white text-center">완료</div>
+    </>
+  );
+}

--- a/src/app/(main)/mypage/profileSetting/page.tsx
+++ b/src/app/(main)/mypage/profileSetting/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 import React from 'react';
 import { useCallback, useEffect, useState } from 'react';
+import { useRecoilState } from 'recoil';
 import useGetUserProfile from '@/lib/hooks/useGetUserProfile';
+import CommunityNav from '@/components/community/CommunityNav';
+import Button from '@/components/common/Button';
 
 export default function ProfileSetting() {
   const { userProfile, isLoading, isError } = useGetUserProfile();
-  const [id, setId] = useState('');
   const [nickname, setNickname] = useState('');
 
   //const handlerChangeId
@@ -24,10 +26,7 @@ export default function ProfileSetting() {
 
   return (
     <>
-      <div className="w-full h-[60px] flex justify-center items-center py-3">
-        <div className="text-h4 font-bold">{'<'}</div>
-        <div className="text-h6"> 프로필 변경 </div>
-      </div>
+      <CommunityNav Icon={false}>프로필 변경</CommunityNav>
 
       <div className=" bg-gray0">
         <div className="flex justify-center">
@@ -35,17 +34,21 @@ export default function ProfileSetting() {
             src={userProfile ? userProfile.profileImage : '없'}
             className="w-16 h-16 bg-gray4 object-cover rounded-full"
           />
-          <button></button>
         </div>
-        <form>
-          <div className="mt-[30px]">이름</div>
-          <input type="text" className="rounded-xl bg-white text-black font-bold" placeholder={userProfile.userId} />
-          <div className="mt-[30px]">닉네임</div>
-          <input type="text" className="rounded-xl bg-white text-black font-bold" placeholder={userProfile.nickname} />
-        </form>
+        <div className="flex justify-center">
+          <form>
+            <div className="mt-[30px] font-bold">닉네임</div>
+            <input
+              type="text"
+              className="rounded-xl px-2 py-1 bg-white font-bold placeholder-black placeholder"
+              placeholder={userProfile != null ? userProfile.nickname : '닉네임'}
+            />
+          </form>
+        </div>
+        <button className="w-full px-2 py-2 rounded-t-2xl text-white bg-primary mt-10">완료</button>
       </div>
 
-      <div className="border rounded-t-xl bg-primary font-bold text-white text-center">완료</div>
+      {/*<Button>완료</Button>*/}
     </>
   );
 }


### PR DESCRIPTION
Closes #87 

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->
1. 마이페이지에서 닉네임을 누르면 수정 페이지로 이동 -> 이미지 및 닉네임 수정시 적용되도록 하였습니다.
2. 마이페이지 내에서 내가 작성한 글, 댓글 등 퍼블리싱은 완료하였고, API 데이터를 넣고 하면 될 것 같습니다.

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->
1. 마이페이지 부분에서 로그인 토큰을 검사하여 회원일 때만 보여야 될 것 같은데, 코드에 보는것 처럼 삼항 연산자를 사용하면 로그인이 되어있어도, null일 때 출력되는 부분이 한 1초간 나타납니다.. 이건 어떻게 해결해야될지...
2. 유림이가 작성했던 코드중에 onNext, onBefore 부분이 있어서 그대로 썼는데, 작동이 안되네요... 다른걸 추가해야하나요?

알게된 점 -> 프로필 수정이나 마이페이지 부분에서, 끝까지 작성하지 않으면 배경색이 꽉 차진 않고 블럭 경계 까지만 찼는데.. 검색해보니 min-h-screen을 배경 적용한 블럭에 입력하면, 꽉 차더라고요. 나중에 이용하시면 될 것 같습니다.

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
1. userProfileSettings.tsx의 경우 이미 작성되어 있어서 작성된 것들을 이용했는데, 페이지를 보고 옮기면서 쓰다보니 내용이 중복된 것 같아서 헤더나 네비 처럼  import를 통해서 옮겨오고 싶었는데, 실패했습니다.. 이건 다음에 도전 해보겠습니다.