### PR TITLE
[#97] accessToken, refreshToken 갱신 에러 해결

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,15 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="" />
+    <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/package-lock.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/(main)/exam/wrong/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/(main)/exam/wrong/page.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/(main)/home/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/(main)/home/page.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/(main)/layout.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/(main)/layout.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/page.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/lib/hooks/useAllIncorrectQuestions.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/useAllIncorrectQuestions.tsx" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -28,7 +36,7 @@
   "keyToString": {
     "RunOnceActivity.OpenProjectViewOnStart": "true",
     "RunOnceActivity.ShowReadmeOnStart": "true",
-    "git-widget-placeholder": "bug-mock__exam__test",
+    "git-widget-placeholder": "bug-login__token__error",
     "last_opened_file_path": "/Users/hwang-yulim/Documents/GitHub/cercat-front",
     "node.js.detected.package.eslint": "true",
     "node.js.detected.package.tslint": "true",
@@ -100,6 +108,7 @@
       <workItem from="1714562222791" duration="8739000" />
       <workItem from="1714611962110" duration="1329000" />
       <workItem from="1714820712763" duration="6383000" />
+      <workItem from="1715048202330" duration="4341000" />
     </task>
     <servers />
   </component>

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { useSearchParams } from 'next/navigation';
 import * as React from 'react';
+import { useEffect } from 'react';
 
 import CorrectRateGraph from '@/components/exam/CorrectRateGraph';
 import StayTimeGraph from '@/components/exam/StayTimeGraph';
@@ -9,6 +11,17 @@ import GoalRunningGraph from '@/components/home/goal-attaining/GoalRunningGraph'
 import ScoredDonutChart from '@/components/home/goal-attaining/ScoredDonutChart';
 
 export default function Home() {
+  const parameter = useSearchParams();
+  const accessToken = parameter.get('accessToken');
+  const refreshToken = parameter.get('refreshToken');
+
+  useEffect(() => {
+    localStorage.setItem('accessToken', accessToken);
+    localStorage.setItem('refreshToken', refreshToken);
+    console.log('액세스 토큰', localStorage.getItem('accessToken'));
+    console.log('리프레시 토큰', localStorage.getItem('refreshToken'));
+  }, [accessToken, refreshToken]);
+
   return (
     <div className="bg-gray0 items-center h-screen overflow-y-auto">
       <div className="w-[90%] mx-auto">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import React, { useEffect } from 'react';
 
-export default function page() {
+export default function Page() {
   const parameter = useSearchParams();
   const accessToken = parameter.get('accessToken');
   const refreshToken = parameter.get('refreshToken');

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,10 +1,4 @@
 import axios from 'axios';
-import { string } from 'prop-types';
-
-import { atom } from 'recoil';
-import qs from 'qs';
-
-import { Param } from '@/types/global';
 
 const client = axios.create({
   baseURL: 'http://cercat.o-r.kr/api/v2',


### PR DESCRIPTION
## ✨ 구현 기능 명세

accessToken, refreshToken 저장 로직 에러 처리

## ✅ PR Point

기존에 accessToken과 refreshToken을 쿼리파라미터에서 때와서 localStorage에 저장을 하는걸 app/page.tsx에서 가져왔었는데,
app/page.tsx이 홈화면으로 변경되어 accessToken이랑 refreshToken이 저장되지 않는 에러가 발생하였습니다. 따라서
accessToken과 refreshToken을 쿼리파라미터에서 때와서 localStorage에 저장하는 로직을 app/home/page.tsx로 변경하여 돌아가도록 했습니다.

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
