### PR TITLE
[#113]모의고사 홈 페이지 api 연결 및 기능 구현

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,12 +5,18 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/lib/hooks/useGetExamResults.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/Question.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/Question.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectGradeCard.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectGradeCard.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/types/exam/type.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/types/exam/type.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SubmitConfirmationModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubmitConfirmationModal.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/TimerModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TimerModal.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/hooks/useCalculateScore.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/hooks/useCalculateScore.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/lib/api/exam.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/api/exam.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/lib/hooks/useMockExamQuestions.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/useMockExamQuestions.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/recoil/exam/atom.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/recoil/exam/atom.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -120,7 +126,7 @@
       <workItem from="1715506546722" duration="28839000" />
       <workItem from="1715652288664" duration="122000" />
       <workItem from="1716123590906" duration="891000" />
-      <workItem from="1716256789152" duration="15085000" />
+      <workItem from="1716256789152" duration="18991000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,10 +5,10 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/TimerModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TimerModal.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/recoil/exam/atom.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/recoil/exam/atom.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -118,7 +118,7 @@
       <workItem from="1715506546722" duration="28839000" />
       <workItem from="1715652288664" duration="122000" />
       <workItem from="1716123590906" duration="891000" />
-      <workItem from="1716256789152" duration="24974000" />
+      <workItem from="1716256789152" duration="25541000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,15 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/src/components/exam/MockExamYearsFilter.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/lib/api/community.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/api/community.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/(main)/exam/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/(main)/exam/page.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/common/Banner.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/common/Banner.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/community/CommentaryBoardList.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/community/CommentaryBoardList.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/community/EditPost.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/community/EditPost.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/community/WriteExplanationPost.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/community/WriteExplanationPost.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/YearSelector.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/YearSelector.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/lib/hooks/useGetMockExamYears.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/useGetMockExamYears.tsx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -27,22 +34,22 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;feature-review__board__list&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/Users/hwang-yulim/Documents/GitHub/cercat-front&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.editor&quot;,
-    &quot;ts.external.directory.path&quot;: &quot;/Users/hwang-yulim/Documents/GitHub/cercat-front/node_modules/typescript/lib&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "git-widget-placeholder": "feature-mock__test__home__api",
+    "last_opened_file_path": "/Users/hwang-yulim/Documents/GitHub/cercat-front",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "preferences.editor",
+    "ts.external.directory.path": "/Users/hwang-yulim/Documents/GitHub/cercat-front/node_modules/typescript/lib",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/public" />
@@ -116,6 +123,7 @@
       <workItem from="1715506546722" duration="28839000" />
       <workItem from="1715652288664" duration="122000" />
       <workItem from="1716123590906" duration="891000" />
+      <workItem from="1716256789152" duration="4606000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,15 +5,12 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/lib/hooks/useGetExamResultRecent.tsx" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/types/exam/type.ts" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/lib/hooks/useGetExamResults.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/(main)/exam/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/(main)/exam/page.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/YearSelector.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/YearSelector.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/lib/hooks/ExamInfoFetcher.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/ExamInfoFetcher.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/lib/hooks/useGetMockExams.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/useGetMockExams.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectGradeCard.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectGradeCard.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/types/exam/type.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/types/exam/type.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -123,7 +120,7 @@
       <workItem from="1715506546722" duration="28839000" />
       <workItem from="1715652288664" duration="122000" />
       <workItem from="1716123590906" duration="891000" />
-      <workItem from="1716256789152" duration="9098000" />
+      <workItem from="1716256789152" duration="15085000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,10 +6,9 @@
   <component name="ChangeListManager">
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/Question.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/Question.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/SubmitConfirmationModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubmitConfirmationModal.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/recoil/exam/atom.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/recoil/exam/atom.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/TimerModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TimerModal.tsx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -30,22 +29,22 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "git-widget-placeholder": "feature-mock__test__home__api",
-    "last_opened_file_path": "/Users/hwang-yulim/Documents/GitHub/cercat-front",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "settings.editor.selected.configurable": "preferences.editor",
-    "ts.external.directory.path": "/Users/hwang-yulim/Documents/GitHub/cercat-front/node_modules/typescript/lib",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;feature-mock__test__home__api&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/Users/hwang-yulim/Documents/GitHub/cercat-front&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.editor&quot;,
+    &quot;ts.external.directory.path&quot;: &quot;/Users/hwang-yulim/Documents/GitHub/cercat-front/node_modules/typescript/lib&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/public" />
@@ -119,7 +118,7 @@
       <workItem from="1715506546722" duration="28839000" />
       <workItem from="1715652288664" duration="122000" />
       <workItem from="1716123590906" duration="891000" />
-      <workItem from="1716256789152" duration="23876000" />
+      <workItem from="1716256789152" duration="24974000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -7,15 +7,8 @@
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/Question.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/Question.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/SubmitConfirmationModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubmitConfirmationModal.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/TimerModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TimerModal.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/hooks/useCalculateScore.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/hooks/useCalculateScore.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/lib/api/exam.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/api/exam.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/lib/hooks/useMockExamQuestions.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/useMockExamQuestions.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/recoil/exam/atom.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/recoil/exam/atom.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -126,7 +119,7 @@
       <workItem from="1715506546722" duration="28839000" />
       <workItem from="1715652288664" duration="122000" />
       <workItem from="1716123590906" duration="891000" />
-      <workItem from="1716256789152" duration="18991000" />
+      <workItem from="1716256789152" duration="23876000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,15 +5,15 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/components/exam/MockExamYearsFilter.tsx" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/lib/hooks/useGetExamResultRecent.tsx" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/types/exam/type.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/(main)/exam/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/(main)/exam/page.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/common/Banner.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/common/Banner.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/community/CommentaryBoardList.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/community/CommentaryBoardList.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/community/EditPost.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/community/EditPost.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/community/WriteExplanationPost.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/community/WriteExplanationPost.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/YearSelector.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/YearSelector.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/lib/hooks/useGetMockExamYears.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/useGetMockExamYears.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/lib/hooks/ExamInfoFetcher.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/ExamInfoFetcher.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/lib/hooks/useGetMockExams.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/useGetMockExams.tsx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -123,7 +123,7 @@
       <workItem from="1715506546722" duration="28839000" />
       <workItem from="1715652288664" duration="122000" />
       <workItem from="1716123590906" duration="891000" />
-      <workItem from="1716256789152" duration="4606000" />
+      <workItem from="1716256789152" duration="9098000" />
     </task>
     <servers />
   </component>

--- a/src/app/(main)/exam/page.tsx
+++ b/src/app/(main)/exam/page.tsx
@@ -1,20 +1,28 @@
-import React from 'react';
+'use client';
+import React, { useState } from 'react';
 
 import Banner from '@/components/common/Banner';
 import Header from '@/components/common/Header';
 import SubjectSessionCard from '@/components/exam/SubjectList';
 import YearSelector from '@/components/exam/YearSelector';
+import useGetMockExamYears from '@/lib/hooks/useGetMockExamYears';
+import NavBar from '@/components/common/NavBar';
 
 const Exam = () => {
   return (
     <div>
       <Header />
       <SolveExamBox />
+      <NavBar />
     </div>
   );
 };
 
 const SolveExamBox = () => {
+  const { examYears } = useGetMockExamYears('YearSelector');
+  const [isClickedYearSelector, setIsClickedYearSelector] = useState<boolean>(false);
+  const [selectedYear, setSelectedYear] = useState<number>(2017);
+
   return (
     <div>
       <div className="px-5 py-4">
@@ -23,8 +31,14 @@ const SolveExamBox = () => {
           <Banner title="실제 출제된 문제를 모아봤어요." buttonText="랜덤 모의고사" href="/exam/wrong" />
         </div>
         <div className="text-h3 mt-[24px] font-bold">모의고사 풀기</div>
-        <YearSelector />
-        <SubjectSessionCard />
+        <YearSelector
+          isClickedYearSelector={isClickedYearSelector}
+          examYears={examYears}
+          setSelectedYear={setSelectedYear}
+          setIsClickedYearSelector={setIsClickedYearSelector}
+          selectedYear={selectedYear}
+        />
+        <SubjectSessionCard selectedYear={selectedYear} />
       </div>
     </div>
   );

--- a/src/app/(main)/exam/page.tsx
+++ b/src/app/(main)/exam/page.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 
 import Banner from '@/components/common/Banner';
 import Header from '@/components/common/Header';
-import NavBar from '@/components/common/NavBar';
-import WrongQuestionsSummaryBox from '@/components/exam/IncorrectQuestionSummaryCard';
 import SubjectSessionCard from '@/components/exam/SubjectList';
 import YearSelector from '@/components/exam/YearSelector';
 
@@ -19,12 +17,12 @@ const Exam = () => {
 const SolveExamBox = () => {
   return (
     <div>
-      <div className="w-[90%] mx-auto">
-        <div className="w-[95%] flex mx-auto space-x-1">
+      <div className="px-5 py-4">
+        <div className="flex gap-x-4 justify-between">
           <Banner title="지금까지 틀린 문제만 모아봤어요." buttonText="틀린 문제 풀기" href="/exam/wrong" />
-          <Banner title="실제 출제된 문제를 모아봤어요" buttonText="랜덤 모의고사" href="/exam/wrong" />
+          <Banner title="실제 출제된 문제를 모아봤어요." buttonText="랜덤 모의고사" href="/exam/wrong" />
         </div>
-        <div className="w-[90%] mx-auto font-black text-h4 mt-5">모의고사 풀기</div>
+        <div className="text-h3 mt-[24px] font-bold">모의고사 풀기</div>
         <YearSelector />
         <SubjectSessionCard />
       </div>

--- a/src/components/common/Banner.tsx
+++ b/src/components/common/Banner.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link';
+import type { SVGProps } from 'react';
+import * as React from 'react';
 
 interface Props {
   title: string;
@@ -10,13 +12,22 @@ export default function Banner(props: Props) {
   const { title, buttonText, href } = props;
 
   return (
-    <div className="mx-auto mt-4 p-3 rounded-3xl bg-second">
-      <div className="px-2">
-        <div className="text-white font-bold text-left text-h4 my-1">{title}</div>
+    <div className="py-[16px] px-[16px] rounded-[32px] bg-second">
+      <div className="flex flex-col gap-y-3">
+        <div className="text-white font-semibold text-left text-h3 my-1">{title}</div>
         <Link href={href}>
-          <div className="inline-block rounded-3xl bg-white text-blue text-h6 my-1 px-3 py-1">{buttonText} ➚</div>
+          <div className="flex px-[12px] py-1 rounded-full items-center w-fit bg-white text-blue text-h6">
+            {buttonText}
+            <MoveIcon />
+          </div>
         </Link>
       </div>
     </div>
   );
 }
+
+const MoveIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={17} height={17} fill="none" {...props}>
+    <path stroke="#6283FD" strokeLinecap="round" strokeLinejoin="round" d="m5.75 11.5 6-6M5.75 5.5h6v6" />
+  </svg>
+);

--- a/src/components/community/CommentaryBoardList.tsx
+++ b/src/components/community/CommentaryBoardList.tsx
@@ -28,7 +28,7 @@ const CommentaryBoardList = (props: Props) => {
   const [selectedCommentaryRoundFilterContent, setSelectedCommentaryRoundFilterContent] = useState<number | string>(
     '전체',
   );
-  const { examYears } = useGetMockExamYears(); //해설 년도 필터값
+  const { examYears } = useGetMockExamYears('CommentaryBoardList'); //해설 년도 필터값
   const { mockExams } = useGetMockExams(1, selectedCommentaryYearFilterContent); //해설 회차 필터값
   const [ref, inView] = useInView();
   const router = useRouter();

--- a/src/components/community/EditPost.tsx
+++ b/src/components/community/EditPost.tsx
@@ -17,7 +17,7 @@ import { EditPostDataType, TipPostTagType } from '@/types/community/type';
 const EditPost = () => {
   const { postDetailData } = useGetPost();
   const { questions } = useMockExamQuestions();
-  const { examYears } = useGetMockExamYears();
+  const { examYears } = useGetMockExamYears('EditPost');
   const [editPostData, setEditPostData] = useRecoilState(editPostDataState);
   const [onlineCourseInputs, setOnlineCourseInputs] = useState<string[]>([]);
   const [workbookInputs, setWorkbookInputs] = useState<string[]>([]);

--- a/src/components/community/WriteExplanationPost.tsx
+++ b/src/components/community/WriteExplanationPost.tsx
@@ -11,7 +11,7 @@ import useMockExamQuestions from '@/lib/hooks/useMockExamQuestions';
 import { createPostDataState, imagePreviewsState, imageUrlListState } from '@/recoil/community/atom';
 
 const WriteExplanationPost = () => {
-  const { examYears } = useGetMockExamYears();
+  const { examYears } = useGetMockExamYears('WriteExplanationPost');
   const { questions } = useMockExamQuestions();
   const [isYearsFilterOpen, setIsYearsFilterOpen] = useState(false);
   const [isRoundsFilterOpen, setIsRoundsFilterOpen] = useState(false);

--- a/src/components/exam/MockExamYearsFilter.tsx
+++ b/src/components/exam/MockExamYearsFilter.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface Props {
+  yearList: number[];
+  setIsClickedYearSelector: React.Dispatch<React.SetStateAction<boolean>>;
+  setSelectedYear: React.Dispatch<React.SetStateAction<number>>;
+}
+const MockExamYearsFilter = (props: Props) => {
+  const { yearList, setIsClickedYearSelector, setSelectedYear } = props;
+  return (
+    <div className={'absolute top-[39%] w-[90%] border-[1px] border-gray2 bg-white rounded-[16px] py-2'}>
+      {!yearList || yearList.length === 0 ? (
+        <div>error</div>
+      ) : (
+        yearList.map((year: number, index: number) => {
+          return (
+            <div
+              key={index}
+              className="text-h4 text-gray3 py-3 px-4 hover:text-black transition"
+              onClick={() => {
+                setIsClickedYearSelector(false);
+                setSelectedYear(year);
+              }}>
+              {year}년도 기출 모의고사
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+};
+export default MockExamYearsFilter;

--- a/src/components/exam/Question.tsx
+++ b/src/components/exam/Question.tsx
@@ -6,7 +6,9 @@ import { useRecoilState } from 'recoil';
 import QuestionContent from '@/components/exam/QuestionContent';
 import useMockExamQuestions from '@/lib/hooks/useMockExamQuestions';
 import {
-  questionIndex, stopwatchIsPaused,
+  mockExamIdState,
+  questionIndex,
+  stopwatchIsPaused,
   stopwatchIsRunning,
   stopwatchTime,
   userAnswerRequests,
@@ -17,7 +19,8 @@ import { Question, QuestionsResponse, UserAnswerRequests } from '@/types/global'
 import { AllQuestionModal } from './AllQuestionModal';
 
 const Question = () => {
-  const { questions, isLoading, isError } = useMockExamQuestions();
+  const [selectedMockExamId, setSelectedMockExamId] = useRecoilState(mockExamIdState);
+  const { questions, isLoading, isError } = useMockExamQuestions(selectedMockExamId);
   const [questionIdx, setQuestionIdx] = useRecoilState<number>(questionIndex);
   const [allQuestionModalIsOpen, setAllQuestionModalIsOpen] = useState(false);
   const [userAnswer, setUserAnswer] = useRecoilState<UserAnswerRequests>(userAnswerRequests);

--- a/src/components/exam/Question.tsx
+++ b/src/components/exam/Question.tsx
@@ -87,7 +87,7 @@ const Question = () => {
   };
 
   /**
-   * 처음 랜더링 될 때, userAnswerLis t을 기본값으로 채워주는 기능
+   * 처음 랜더링 될 때, userAnswerList 을 기본값으로 채워주는 기능
    */
   useEffect(() => {
     if (questions?.length > 0 && userAnswerList.length === 0) {

--- a/src/components/exam/SessionModal.tsx
+++ b/src/components/exam/SessionModal.tsx
@@ -29,8 +29,8 @@ const SessionModal: React.FC<SessionModalProps> = ({ round, mockExamId, closeMod
     <div>
       <div className="fixed z-20 inset-0 flex items-center justify-center bg-black bg-opacity-30">
         <div className="w-[80%]">
-          <button onClick={closeModal} className="w-full flex justify-end text-white text-h6 px-2 my-2">
-            닫기 X
+          <button onClick={closeModal} className="w-full flex justify-end items-center text-white text-h6 px-2 my-2">
+            닫기 <CancleIcon />
           </button>
           <div className="relative bg-white rounded-[32px]">
             <div className="flex flex-col gap-y-4 p-5">
@@ -61,8 +61,7 @@ const SessionModal: React.FC<SessionModalProps> = ({ round, mockExamId, closeMod
                 </div>
               </div>
               <div>
-                {examResults && examResults[examResults?.length - 1]?.subjectResults
-                  ? (
+                {examResults && examResults[examResults?.length - 1]?.subjectResults ? (
                   <div className={'flex flex-col gap-y-2'}>
                     <div className="text-h6 font-semibold">과목별 맞춘 문제 수</div>
                     <div className={'flex'}>
@@ -111,5 +110,28 @@ const AfterIcon = (props: SVGProps<SVGSVGElement>) => (
 const MoveIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg xmlns="http://www.w3.org/2000/svg" width={16} height={17} fill="none" {...props}>
     <path stroke="#0D0E10" strokeLinecap="round" strokeLinejoin="round" d="m5 11.5 6-6M5 5.5h6v6" />
+  </svg>
+);
+
+const CancleIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} fill="none" {...props}>
+    <mask
+      id="a"
+      width={24}
+      height={24}
+      x={0}
+      y={0}
+      maskUnits="userSpaceOnUse"
+      style={{
+        maskType: 'alpha',
+      }}>
+      <path fill="#D9D9D9" d="M0 0h24v24H0z" />
+    </mask>
+    <g mask="url(#a)">
+      <path
+        fill="#fff"
+        d="m12 12.708-5.246 5.246a.5.5 0 0 1-.344.15.47.47 0 0 1-.364-.15.5.5 0 0 1-.16-.354.5.5 0 0 1 .16-.354L11.292 12 6.046 6.754a.5.5 0 0 1-.15-.344.47.47 0 0 1 .15-.364.5.5 0 0 1 .354-.16.5.5 0 0 1 .354.16L12 11.292l5.246-5.246a.5.5 0 0 1 .344-.15.47.47 0 0 1 .364.15.5.5 0 0 1 .16.354.5.5 0 0 1-.16.354L12.708 12l5.246 5.246a.5.5 0 0 1 .15.344.47.47 0 0 1-.15.364.5.5 0 0 1-.354.16.5.5 0 0 1-.354-.16z"
+      />
+    </g>
   </svg>
 );

--- a/src/components/exam/SessionModal.tsx
+++ b/src/components/exam/SessionModal.tsx
@@ -9,15 +9,15 @@ import SubjectGradeCard from './SubjectGradeCard';
 
 interface SessionModalProps {
   round: number;
-  MockExamId: number;
+  mockExamId: number;
   closeModal: () => void;
   openTimerModal: () => void;
   total: number;
 }
 
-const SessionModal: React.FC<SessionModalProps> = ({ round, MockExamId, closeModal, openTimerModal, total }) => {
+const SessionModal: React.FC<SessionModalProps> = ({ round, mockExamId, closeModal, openTimerModal, total }) => {
   const [changedRound, setChangedRound] = useState<number>(0);
-  const { examResults } = useGetExamResults(MockExamId);
+  const { examResults } = useGetExamResults(mockExamId);
 
   useEffect(() => {
     if (round) {

--- a/src/components/exam/SessionModal.tsx
+++ b/src/components/exam/SessionModal.tsx
@@ -1,63 +1,88 @@
 import Link from 'next/link';
-import React, { useState } from 'react';
-import { useRecoilState } from 'recoil';
+import { SVGProps, useEffect, useState } from 'react';
+import React from 'react';
 
-import { Session } from '@/types/global';
-import { selectedSessionState } from '@/utils/recoilState';
+import useGetExamResultRecent from '@/lib/hooks/useGetExamResultRecent';
+import useGetExamResults from '@/lib/hooks/useGetExamResults';
 
 import SubjectGradeCard from './SubjectGradeCard';
 
 interface SessionModalProps {
+  round: number;
+  MockExamId: number;
   closeModal: () => void;
   openTimerModal: () => void;
-  round: number;
-  main: number;
   total: number;
 }
 
-const SessionModal: React.FC<SessionModalProps> = ({ closeModal, openTimerModal, round, main, total }) => {
-  const [selectedSession, setSelectedSession] = useRecoilState<Session | null>(selectedSessionState);
+const SessionModal: React.FC<SessionModalProps> = ({ round, MockExamId, closeModal, openTimerModal, total }) => {
+  const [changedRound, setChangedRound] = useState<number>(0);
+  const { examResults } = useGetExamResults(MockExamId);
+
+  useEffect(() => {
+    if (round) {
+      setChangedRound(round);
+    }
+  }, [round]);
 
   return (
     <div>
-      <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-30">
+      <div className="fixed z-20 inset-0 flex items-center justify-center bg-black bg-opacity-30">
         <div className="w-[80%]">
           <button onClick={closeModal} className="w-full flex justify-end text-white text-h6 px-2 my-2">
             닫기 X
           </button>
-          <div className="bg-white rounded-3xl">
-            <div className="w-[90%] mx-auto">
-              <h2 className="flex justify-between text-h4 font-bold p-4">
-                <button>{'<'}</button>
+          <div className="relative bg-white rounded-[32px]">
+            <div className="flex flex-col gap-y-4 p-5">
+              <div className=" flex justify-center text-h4 font-bold">
                 <div>{`${round}회차`}</div>
-                <button>{'>'}</button>
-              </h2>
-              <div className="border-t border-gray1"></div>
-              <div className="flex justify-between my-3">
-                <div>
-                  <div className="font-bold text-h6">최근 점수</div>
-                  <div className="flex items-end">
-                    <div className="font-bold text-h1">{`${main}점`}</div>
-                    <div className="text-gray3 text-h6 mb-1">/{`${total}점`}</div>
-                  </div>
-                </div>
-                <Link href={'/exam/report'} className="h-1/2 bg-gray0 rounded-3xl text-h6 font-bold p-2">
-                  성적 리포트 ➚
-                </Link>
               </div>
-              <div className="text-h6 font-bold mt-5">과목별 맞춘 문제 수</div>
-              <div className="flex my-2">
-                {/* {subjects?.map((subject, index) => (
-                  <SubjectGradeCard key={index} name={'하이'} correctAnswer={12} totalCorrect={50} />
-                ))} */}
-                <SubjectGradeCard name={'하이'} correctAnswer={12} totalCorrect={50} />
-                <SubjectGradeCard name={'하이'} correctAnswer={12} totalCorrect={50} />
-                <SubjectGradeCard name={'하이'} correctAnswer={12} totalCorrect={50} />
+              <div className="border-t border-gray1"></div>
+              <div className="flex justify-between">
+                {examResults && examResults[examResults?.length - 1]?.totalScore ? (
+                  <Link
+                    href={'/exam/report'}
+                    className="absolute right-5 px-3 py-2 flex gap-x-2 items-center bg-gray0 rounded-full text-h6">
+                    <span>성적 리포트</span> <MoveIcon />
+                  </Link>
+                ) : null}
+                <div>
+                  <div className="font-semibold text-h6">최근 점수</div>
+                  {examResults && examResults[examResults?.length - 1]?.totalScore ? (
+                    <div className={''}>
+                      <div className="flex items-end">
+                        <div className="font-bold text-h1">{examResults[examResults?.length - 1].totalScore}점</div>
+                        <div className="text-gray3 text-h6 mb-1">/{`${total}점`}</div>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="font-bold text-h1">미응시</div>
+                  )}
+                </div>
+              </div>
+              <div>
+                {examResults && examResults[examResults?.length - 1]?.subjectResults
+                  ? (
+                  <div className={'flex flex-col gap-y-2'}>
+                    <div className="text-h6 font-semibold">과목별 맞춘 문제 수</div>
+                    <div className={'flex'}>
+                      {examResults[examResults?.length - 1]?.subjectResults?.map((subjectResult, index) => {
+                        return (
+                          <div className={'w-full'} key={index}>
+                            <SubjectGradeCard
+                              name={subjectResult.subject.subjectName}
+                              correctAnswer={subjectResult.numberOfCorrect}
+                              totalCorrect={20}
+                            />
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ) : null}
               </div>
               <div className="flex justify-center">
-                <button
-                  onClick={() => openTimerModal()}
-                  className="w-full bg-black text-white rounded-3xl text-h5 p-4 my-4">
+                <button onClick={() => openTimerModal()} className="w-full bg-black text-white rounded-3xl text-h5 p-4">
                   시험 보기
                 </button>
               </div>
@@ -70,3 +95,21 @@ const SessionModal: React.FC<SessionModalProps> = ({ closeModal, openTimerModal,
 };
 
 export default SessionModal;
+
+const BeforeIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={28} height={28} fill="none" {...props}>
+    <path stroke="#0D0E10" strokeLinecap="round" strokeLinejoin="round" d="m18 22-8-8 8-8" />
+  </svg>
+);
+
+const AfterIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={28} height={28} fill="none" {...props}>
+    <path stroke="#0D0E10" strokeLinecap="round" strokeLinejoin="round" d="m10 6 8 8-8 8" />
+  </svg>
+);
+
+const MoveIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={16} height={17} fill="none" {...props}>
+    <path stroke="#0D0E10" strokeLinecap="round" strokeLinejoin="round" d="m5 11.5 6-6M5 5.5h6v6" />
+  </svg>
+);

--- a/src/components/exam/SubjectCard.tsx
+++ b/src/components/exam/SubjectCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 
 import useGetExamResultRecent from '@/lib/hooks/useGetExamResultRecent';
@@ -7,6 +7,7 @@ import { selectedSessionState, selectedSubjectState } from '@/utils/recoilState'
 
 import SessionModal from './SessionModal';
 import TimerModal from './TimerModal';
+import { timeLimitState } from '@/recoil/exam/atom';
 
 interface SubjectCard {
   timeLimit: number;
@@ -23,6 +24,14 @@ const SubjectCard: React.FC<SubjectCard> = ({ timeLimit, round, mockExamId, tota
   // 모달 관련 states
   const [sessionModalIsOpen, setSessionModalIsOpen] = useState(false);
   const [timerModalIsOpen, setTimerModalIsOpen] = useState(false);
+  const [time, setTime] = useRecoilState(timeLimitState);
+
+  //제한 시간 설정
+  useEffect(() => {
+    if (timeLimit != 0) {
+      setTime(timeLimit);
+    }
+  }, [timeLimit]);
 
   // 모달이 열릴때 세션 상태 설정
   const openSessionModal = () => {

--- a/src/components/exam/SubjectCard.tsx
+++ b/src/components/exam/SubjectCard.tsx
@@ -9,13 +9,14 @@ import SessionModal from './SessionModal';
 import TimerModal from './TimerModal';
 
 interface SubjectCard {
+  timeLimit: number;
   round: number;
-  MockExamId: number;
+  mockExamId: number;
   total: number;
 }
 
-const SubjectCard: React.FC<SubjectCard> = ({ round, MockExamId, total }) => {
-  const { examResultRecent } = useGetExamResultRecent(MockExamId);
+const SubjectCard: React.FC<SubjectCard> = ({ timeLimit, round, mockExamId, total }) => {
+  const { examResultRecent } = useGetExamResultRecent(mockExamId);
   const [selectedSubject, setSelectedSubject] = useRecoilState<SubjectInfo | null>(selectedSubjectState);
   const [selectedSession, setSelectedSession] = useRecoilState<Session | null>(selectedSessionState);
 
@@ -64,7 +65,7 @@ const SubjectCard: React.FC<SubjectCard> = ({ round, MockExamId, total }) => {
       </div>
       {sessionModalIsOpen && (
         <SessionModal
-          MockExamId={MockExamId}
+          mockExamId={mockExamId}
           closeModal={closeSessionModal}
           openTimerModal={openTimerModal}
           total={total}
@@ -72,7 +73,15 @@ const SubjectCard: React.FC<SubjectCard> = ({ round, MockExamId, total }) => {
         />
       )}
       {/* 타이머 모달에 대한 코드 */}
-      {timerModalIsOpen && <TimerModal closeTimerModal={closeTimerModal} closeSessionModal={closeSessionModal} />}
+      {timerModalIsOpen && (
+        <TimerModal
+          mockExamId={mockExamId}
+          timeLimit={timeLimit}
+          round={round}
+          closeTimerModal={closeTimerModal}
+          closeSessionModal={closeSessionModal}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/exam/SubjectCard.tsx
+++ b/src/components/exam/SubjectCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 
+import useGetExamResultRecent from '@/lib/hooks/useGetExamResultRecent';
 import { Session, SubjectInfo } from '@/types/global';
 import { selectedSessionState, selectedSubjectState } from '@/utils/recoilState';
 
@@ -9,12 +10,12 @@ import TimerModal from './TimerModal';
 
 interface SubjectCard {
   round: number;
-  score: number;
+  MockExamId: number;
   total: number;
-  isTaken: boolean;
 }
 
-const SubjectCard: React.FC<SubjectCard> = ({ round, score, total, isTaken }) => {
+const SubjectCard: React.FC<SubjectCard> = ({ round, MockExamId, total }) => {
+  const { examResultRecent } = useGetExamResultRecent(MockExamId);
   const [selectedSubject, setSelectedSubject] = useRecoilState<SubjectInfo | null>(selectedSubjectState);
   const [selectedSession, setSelectedSession] = useRecoilState<Session | null>(selectedSessionState);
 
@@ -44,19 +45,20 @@ const SubjectCard: React.FC<SubjectCard> = ({ round, score, total, isTaken }) =>
 
   return (
     <div>
-      <div className="mx-2 p-3 border border-gray2 rounded-3xl">
-        <div className="text-black font-bold text-center">{`${round}회차`}</div>
-        <div className="border-t border-gray1 my-2"></div>
-        <div className="text-black text-center text-h7">최근 점수</div>
-        {isTaken ? (
-          <ul className="flex text-center justify-center">
-            <li className="font-bold text-h2">{`${score}점`}</li>
-            <div className="mt-1 text-gray3">{`/${total}점`}</div>
-          </ul>
-        ) : (
-          <p className="text-center text-h2 font-bold">미응시</p>
-        )}
-        <button onClick={() => openSessionModal()} className="w-full bg-gray1 rounded-3xl py-3 mt-4 text-h6 font-bold">
+      <div className="flex flex-col gap-y-4 p-3 border-[1px] border-gray2 rounded-[32px]">
+        <div className="font-semibold text-center pb-2 border-b border-gray1">{`${round}회차`}</div>
+        <div>
+          <div className="text-black text-center text-h7">최근 점수</div>
+          {examResultRecent ? (
+            <ul className="flex items-end justify-center">
+              <li className="font-bold text-h2">{`${examResultRecent.totalScore}점`}</li>
+              <div className="mb-[3px] text-gray3 text-h6">{`/${total}점`}</div>
+            </ul>
+          ) : (
+            <p className="text-center text-h2 font-semibold">미응시</p>
+          )}
+        </div>
+        <button onClick={() => openSessionModal()} className="w-full bg-gray0 rounded-3xl py-3 text-h6">
           시험 보기
         </button>
       </div>
@@ -65,7 +67,7 @@ const SubjectCard: React.FC<SubjectCard> = ({ round, score, total, isTaken }) =>
           closeModal={closeSessionModal}
           openTimerModal={openTimerModal}
           round={round}
-          main={score}
+          main={examResultRecent ? examResultRecent.totalScore : 0}
           total={total}
         />
       )}

--- a/src/components/exam/SubjectCard.tsx
+++ b/src/components/exam/SubjectCard.tsx
@@ -64,11 +64,11 @@ const SubjectCard: React.FC<SubjectCard> = ({ round, MockExamId, total }) => {
       </div>
       {sessionModalIsOpen && (
         <SessionModal
+          MockExamId={MockExamId}
           closeModal={closeSessionModal}
           openTimerModal={openTimerModal}
-          round={round}
-          main={examResultRecent ? examResultRecent.totalScore : 0}
           total={total}
+          round={round}
         />
       )}
       {/* 타이머 모달에 대한 코드 */}

--- a/src/components/exam/SubjectGradeCard.tsx
+++ b/src/components/exam/SubjectGradeCard.tsx
@@ -13,8 +13,8 @@ interface SubjectGradeCardProps {
 // 세부 과목별 성적을 나타내는 표 컴포넌트
 const SubjectGradeCard: React.FC<SubjectGradeCardProps> = ({ name, correctAnswer, totalCorrect }) => {
   return (
-    <div className="w-full border border-gray2">
-      <div className="text-lg text-center text-h6 py-2">{name}</div>
+    <div className={'w-full border border-gray2'}>
+      <div className="text-h6 text-center py-2 w-full">{name}</div>
       <div className="flex justify-center border-t border-gray2 py-2">
         <div className="flex items-end">
           <div className="font-bold text-h3">{correctAnswer}개</div>

--- a/src/components/exam/SubjectList.tsx
+++ b/src/components/exam/SubjectList.tsx
@@ -1,9 +1,11 @@
 'use client';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import SubjectCard from '@/components/exam/SubjectCard';
 import useGetMockExams from '@/lib/hooks/useGetMockExams';
 import { ReviewIncorrectMockExam } from '@/types/global';
+import { useRecoilState } from 'recoil';
+import { timeLimitState } from '@/recoil/exam/atom';
 
 interface Props {
   selectedYear: number;

--- a/src/components/exam/SubjectList.tsx
+++ b/src/components/exam/SubjectList.tsx
@@ -18,7 +18,11 @@ const SubjectSessionCard = (props: Props) => {
       {mockExams?.map((mockExam: ReviewIncorrectMockExam, index: number) => {
         return (
           <div key={index}>
-            <SubjectCard total={300} round={mockExam.round} MockExamId={mockExam.MockExamId}></SubjectCard>
+            <SubjectCard
+              timeLimit={mockExam.timeLimit}
+              total={300}
+              round={mockExam.round}
+              mockExamId={mockExam.MockExamId}></SubjectCard>
           </div>
         );
       })}

--- a/src/components/exam/SubjectList.tsx
+++ b/src/components/exam/SubjectList.tsx
@@ -1,66 +1,28 @@
 'use client';
-import React, { useEffect } from 'react';
-import { useRecoilState } from 'recoil';
+import React from 'react';
 
-import { useGetExamYearData } from '@/lib/hooks/ExamInfoFetcher';
-import { roundsArrayState, YearState } from '@/utils/recoilState';
+import SubjectCard from '@/components/exam/SubjectCard';
+import useGetMockExams from '@/lib/hooks/useGetMockExams';
+import { ReviewIncorrectMockExam } from '@/types/global';
 
-import SubjectCard from './SubjectCard';
-
+interface Props {
+  selectedYear: number;
+}
 // 해당하는 연도의 회차별 데이터를 모두 출력
-const SubjectSessionCard: React.FC = ({}) => {
-  // 연도 데이터 불러오기
-  const [selectedYear] = useRecoilState<Number | undefined>(YearState);
-  const [roundArrays, setRoundArrays] = useRecoilState<number[] | undefined>(roundsArrayState);
+const SubjectSessionCard = (props: Props) => {
+  const { selectedYear } = props;
+  const { mockExams } = useGetMockExams(1, selectedYear);
 
-  // ExamID, round, istake 정보 실려옴
-  const { YearData } = useGetExamYearData(1, selectedYear);
-
-  // api 살아나면 살릴부분
-  // const rounds = YearData?.result;
-
-  const rounds = [
-    { round: 1, mockExamId: 23, isTake: true },
-    { round: 2, mockExamId: 56, isTake: false },
-    { round: 3, mockExamId: 89, isTake: true },
-  ];
-
-  console.log(rounds);
-
-  // api 살아나면 이부분 살려야함
-  // useEffect(() => {
-  //   if (rounds) {
-  //     const roundArray = rounds.map((item) => item.round);
-  //     setRoundArrays(roundArray);
-  //   }
-  // }, [rounds, setRoundArrays]);
-
-  if (!rounds) {
-    return (
-      <div>
-        {/* 이 부분 모듈로 뺍니다*/}
-        데이터 불러오는 중
-      </div>
-    );
-  }
-
-  // 여기서 selectedSession 에 대한 전역 상태가 결정됩니다.
   return (
-    <>
-      <div className="flex flex-wrap mt-5">
-        {rounds?.map((round, index) => {
-          if (round.round) {
-            return (
-              <div key={index} className="w-1/2 mb-4">
-                <SubjectCard round={round.round} score={round.mockExamId} total={50} isTaken={round.isTake} />
-              </div>
-            );
-          } else {
-            return null;
-          }
-        })}
-      </div>
-    </>
+    <div className={'mt-[16px] grid grid-cols-2 gap-x-4 gap-y-4'}>
+      {mockExams?.map((mockExam: ReviewIncorrectMockExam, index: number) => {
+        return (
+          <div key={index}>
+            <SubjectCard total={300} round={mockExam.round} MockExamId={mockExam.MockExamId}></SubjectCard>
+          </div>
+        );
+      })}
+    </div>
   );
 };
 

--- a/src/components/exam/SubmitConfirmationModal.tsx
+++ b/src/components/exam/SubmitConfirmationModal.tsx
@@ -2,14 +2,7 @@ import { useRouter } from 'next/navigation';
 import * as React from 'react';
 import { useRecoilState } from 'recoil';
 
-import { postSubjectResultRequestsList } from '@/lib/api/exam';
-import {
-  mockExamIdState,
-  stopwatchIsPaused,
-  stopwatchIsRunning,
-  subjectResultRequestsList,
-  timerIsPaused,
-} from '@/recoil/exam/atom';
+import { stopwatchIsPaused, stopwatchIsRunning, timerIsPaused } from '@/recoil/exam/atom';
 
 interface Props {
   isSubmitConfirmationModalOpen: boolean;
@@ -17,14 +10,12 @@ interface Props {
 }
 
 const SubmitConfirmationModal = (props: Props) => {
-  const [selectedMockExamId, setSelectedMockExamId] = useRecoilState(mockExamIdState);
   const { isSubmitConfirmationModalOpen, setIsSubmitConfirmationModalOpen } = props;
   // 모달창을 띄우면 타이머를 잠시 멈추게 하는 state
   const [isPausedTimer, setIsPausedTimer] = useRecoilState(timerIsPaused);
   // 문제당 머문시간을 잠시 멈추는
   const [isPausedStopWatch, setIsPausedStopWatch] = useRecoilState(stopwatchIsPaused);
   const [isRunning, setIsRunning] = useRecoilState<boolean>(stopwatchIsRunning);
-  const [subjectResultList, setSubjectResultList] = useRecoilState(subjectResultRequestsList)
   const router = useRouter();
 
   /**
@@ -33,6 +24,7 @@ const SubmitConfirmationModal = (props: Props) => {
   const onMove = async () => {
     router.push('/exam/result');
   };
+
   return (
     <>
       <div
@@ -58,9 +50,8 @@ const SubmitConfirmationModal = (props: Props) => {
             </button>
             <button
               onClick={async () => {
-                setIsRunning(false);
+                setIsRunning(false); //제출 트릭
                 setIsSubmitConfirmationModalOpen(!isSubmitConfirmationModalOpen);
-                await postSubjectResultRequestsList(subjectResultList, selectedMockExamId).then((r) => console.log(r));
                 await onMove();
               }}
               className={'bg-black rounded-full text-white py-[7px] px-3'}>

--- a/src/components/exam/SubmitConfirmationModal.tsx
+++ b/src/components/exam/SubmitConfirmationModal.tsx
@@ -2,7 +2,14 @@ import { useRouter } from 'next/navigation';
 import * as React from 'react';
 import { useRecoilState } from 'recoil';
 
-import { stopwatchIsPaused, stopwatchIsRunning, timerIsPaused } from '@/recoil/exam/atom';
+import { postSubjectResultRequestsList } from '@/lib/api/exam';
+import {
+  mockExamIdState,
+  stopwatchIsPaused,
+  stopwatchIsRunning,
+  subjectResultRequestsList,
+  timerIsPaused,
+} from '@/recoil/exam/atom';
 
 interface Props {
   isSubmitConfirmationModalOpen: boolean;
@@ -10,21 +17,22 @@ interface Props {
 }
 
 const SubmitConfirmationModal = (props: Props) => {
+  const [selectedMockExamId, setSelectedMockExamId] = useRecoilState(mockExamIdState);
   const { isSubmitConfirmationModalOpen, setIsSubmitConfirmationModalOpen } = props;
   // 모달창을 띄우면 타이머를 잠시 멈추게 하는 state
   const [isPausedTimer, setIsPausedTimer] = useRecoilState(timerIsPaused);
   // 문제당 머문시간을 잠시 멈추는
   const [isPausedStopWatch, setIsPausedStopWatch] = useRecoilState(stopwatchIsPaused);
   const [isRunning, setIsRunning] = useRecoilState<boolean>(stopwatchIsRunning);
+  const [subjectResultList, setSubjectResultList] = useRecoilState(subjectResultRequestsList)
   const router = useRouter();
 
   /**
    * 제출 버튼을 눌렀을 때, 결과 페이지로 이동하는 함수
    */
-  const onMove = () => {
+  const onMove = async () => {
     router.push('/exam/result');
   };
-
   return (
     <>
       <div
@@ -49,10 +57,11 @@ const SubmitConfirmationModal = (props: Props) => {
               닫기
             </button>
             <button
-              onClick={() => {
+              onClick={async () => {
                 setIsRunning(false);
                 setIsSubmitConfirmationModalOpen(!isSubmitConfirmationModalOpen);
-                onMove();
+                await postSubjectResultRequestsList(subjectResultList, selectedMockExamId).then((r) => console.log(r));
+                await onMove();
               }}
               className={'bg-black rounded-full text-white py-[7px] px-3'}>
               제출하기

--- a/src/components/exam/TestSubmitOrCancle.tsx
+++ b/src/components/exam/TestSubmitOrCancle.tsx
@@ -7,6 +7,7 @@ import useCalculateScore from '@/hooks/useCalculateScore';
 import { postSubjectResultRequestsList } from '@/lib/api/exam';
 import useMockExamQuestions from '@/lib/hooks/useMockExamQuestions';
 import {
+  mockExamIdState,
   questionIndex,
   stopwatchIsPaused,
   stopwatchIsRunning,
@@ -35,7 +36,8 @@ const TestSubmitOrCancle = (props: Props) => {
     isAutoSubmitTimeUpModalOpen,
     setIsAutoSubmitTimeUpModalOpen,
   } = props;
-  const { calculateScore, prepareAndScoreSubjectResults } = useCalculateScore();
+  const [selectedMockExamId, setSelectedMockExamId] = useRecoilState(mockExamIdState);
+  const { calculateScore, prepareAndScoreSubjectResults } = useCalculateScore(selectedMockExamId);
   // 남은 시간(타이머) TODO: questions[0].mockExam.timeLimit으로 변경
   const [timeLeft, setTimeLeft] = useState(5400000); //5400000
   // 각 문제당 걸린 시간
@@ -117,17 +119,6 @@ const TestSubmitOrCancle = (props: Props) => {
       prepareAndScoreSubjectResults();
     }
   }, [userAnswerList[0]?.isCorrect]);
-
-  /**
-   * prepareAndScoreSubjectResults 가 다 완료되고, subjectResultList 에 값이 다 저장될 때,
-   * 서버에 post 요청을 보내는 코드
-   */
-  useEffect(() => {
-    if (subjectResultList.length !== 0) {
-      postSubjectResultRequestsList(subjectResultList).then((r) => console.log(r));
-      setSubjectResultList([]); //다시 제출 방지
-    }
-  }, [subjectResultList]);
 
   /**
    * 시간이 종료되었을 때, 자동 제출되는 로직

--- a/src/components/exam/TestSubmitOrCancle.tsx
+++ b/src/components/exam/TestSubmitOrCancle.tsx
@@ -38,7 +38,7 @@ const TestSubmitOrCancle = (props: Props) => {
   } = props;
   const [selectedMockExamId, setSelectedMockExamId] = useRecoilState(mockExamIdState);
   // 남은 시간(타이머) TODO: questions[0].mockExam.timeLimit으로 변경
-  const [timeLeft, setTimeLeft] = useState(5400000); //5400000
+  const [timeLeft, setTimeLeft] = useState(10000); //5400000
   // 각 문제당 걸린 시간
   const [time, setTime] = useRecoilState<number>(stopwatchTime);
   const [isRunning, setIsRunning] = useRecoilState<boolean>(stopwatchIsRunning);
@@ -95,6 +95,16 @@ const TestSubmitOrCancle = (props: Props) => {
     calculateScore();
   };
 
+  /**
+   * 시간이 종료되었을 때, 자동 제출되는 로직
+   */
+  useEffect(() => {
+    if (timeLeft <= 0) {
+      setIsRunning(false);
+      setIsAutoSubmitTimeUpModalOpen(!isAutoSubmitTimeUpModalOpen);
+    }
+  }, [timeLeft]);
+
   useEffect(() => {
     if (!isRunning) {
       recordSessionTime();
@@ -129,16 +139,6 @@ const TestSubmitOrCancle = (props: Props) => {
       setSubjectResultList([]); //다시 제출 방지
     }
   }, [subjectResultList]);
-
-  /**
-   * 시간이 종료되었을 때, 자동 제출되는 로직
-   */
-  useEffect(() => {
-    if (timeLeft < 0) {
-      setIsRunning(false);
-      setIsAutoSubmitTimeUpModalOpen(!isAutoSubmitTimeUpModalOpen);
-    }
-  }, [timeLeft]);
 
   return (
     <>

--- a/src/components/exam/TestSubmitOrCancle.tsx
+++ b/src/components/exam/TestSubmitOrCancle.tsx
@@ -12,7 +12,7 @@ import {
   stopwatchIsPaused,
   stopwatchIsRunning,
   stopwatchTime,
-  subjectResultRequestsList,
+  subjectResultRequestsList, timeLimitState,
   timerIsPaused,
   userAnswerRequestsList,
 } from '@/recoil/exam/atom';
@@ -37,8 +37,10 @@ const TestSubmitOrCancle = (props: Props) => {
     setIsAutoSubmitTimeUpModalOpen,
   } = props;
   const [selectedMockExamId, setSelectedMockExamId] = useRecoilState(mockExamIdState);
-  // 남은 시간(타이머) TODO: questions[0].mockExam.timeLimit으로 변경
-  const [timeLeft, setTimeLeft] = useState(10000); //5400000
+  //시험 제한 시간
+  const [timeLimit, setTimeLimit] = useRecoilState(timeLimitState);
+  // 남은 시간(타이머)
+  const [timeLeft, setTimeLeft] = useState(timeLimit); //5400000 -> 1시간 30분, 10000 -> 10초
   // 각 문제당 걸린 시간
   const [time, setTime] = useRecoilState<number>(stopwatchTime);
   const [isRunning, setIsRunning] = useRecoilState<boolean>(stopwatchIsRunning);

--- a/src/components/exam/TimerModal.tsx
+++ b/src/components/exam/TimerModal.tsx
@@ -1,54 +1,65 @@
 'use client';
-import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import React, { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 
-import { Session } from '@/types/global';
-import { selectedSessionState } from '@/utils/recoilState';
+import { mockExamIdState } from '@/recoil/exam/atom';
 
 interface SessionModalProps {
+  mockExamId: number;
   closeTimerModal: () => void;
   closeSessionModal: () => void;
+  round: number;
+  timeLimit: number;
 }
 
-const TimerModal: React.FC<SessionModalProps> = ({ closeTimerModal, closeSessionModal }) => {
-  const [selectedSession, setSelectedSession] = useRecoilState<Session | null>(selectedSessionState);
+const TimerModal: React.FC<SessionModalProps> = ({
+  mockExamId,
+  timeLimit,
+  round,
+  closeTimerModal,
+  closeSessionModal,
+}) => {
+  const [selectedMockExamId, setSelectedMockExamId] = useRecoilState(mockExamIdState);
+  const router = useRouter();
   // 타이머 모달이 나타나면 기존 세션 모달을 종료 위한 동작
   useEffect(() => {
     // 타이머 모달이 나타난 후에 실행되는 부분
     closeSessionModal();
   }, [closeSessionModal]);
-  // 체크박스 체크 여부 state
-  const [isChecked, setIsChecked] = useState(false);
-
-  // 체크박스 state 변경 함수
-  const handleCheckboxChange = () => {
-    setIsChecked((prev) => !prev);
-  };
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-30">
+    <div className="fixed z-20 inset-0 flex items-center justify-center bg-black bg-opacity-30">
       <div className="w-[80%]">
         <button onClick={closeTimerModal} className="w-full flex justify-end text-white text-h6 px-2 my-2">
           닫기 X
         </button>
-        <div className="bg-white rounded-3xl">
-          <div className="w-[90%] mx-auto">
-            <h2 className="flex justify-center text-h4 font-bold p-4">
-              <div>{`${selectedSession?.sessionNumber}회차`}</div>
-            </h2>
+        <div className="p-5 bg-white rounded-[32px] flex flex-col gap-y-6">
+          <div className="flex flex-col gap-y-4">
+            <div className="flex justify-center text-h4 font-semibold">{`${round}회차`}</div>
             <div className="border-t border-gray1"></div>
-            <div className="flex justify-center font-bold my-4">시험 시간 설정</div>
-            <div className="flex justify-center rounded-3xl bg-gray1 p-4">여기에 타이머가 들어가야하는데</div>
-            <div className="flex justify-center mt-3">
-              <label className="text-h5">
-                <input className="mx-2" type="checkbox" checked={isChecked} onChange={handleCheckboxChange} />
-              </label>
-              <div className="text-h5">종료 시 소리 알림</div>
-            </div>
-            <div className="flex justify-center">
-              <button className="w-full bg-black text-white rounded-3xl text-h5 p-3 my-4">시험 보기</button>
+            <div className={'flex flex-col gap-y-2'}>
+              <div className="flex justify-center font-semibold">시험 시간 설정</div>
+              <div className="flex gap-x-8 justify-center rounded-[24px] bg-gray0 p-4">
+                <div className={'flex items-end gap-x-[2px]'}>
+                  <span className={'text-h2 font-semibold text-gray3'}>{Math.floor(timeLimit / 3600000)}</span>
+                  <span className={'text-h4 font-normal text-black pb-[3px]'}>시간</span>
+                </div>
+                <div className={'flex items-end gap-x-[2px]'}>
+                  <span className={'text-h2 font-semibold text-gray3'}>{Math.floor(timeLimit / 60000)}</span>
+                  <span className={'text-h4 font-normal text-black pb-[3px]'}>분</span>
+                </div>
+              </div>
             </div>
           </div>
+          <button
+            onClick={() => {
+              setSelectedMockExamId(mockExamId);
+              router.push('/exam/test');
+            }}
+            className="flex justify-center w-full bg-black text-white rounded-3xl text-h5 p-4">
+            시험 보기
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/exam/TimerModal.tsx
+++ b/src/components/exam/TimerModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useRouter } from 'next/navigation';
-import React, { useEffect } from 'react';
+import React, { SVGProps, useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 
 import { mockExamIdState } from '@/recoil/exam/atom';
@@ -31,8 +31,8 @@ const TimerModal: React.FC<SessionModalProps> = ({
   return (
     <div className="fixed z-20 inset-0 flex items-center justify-center bg-black bg-opacity-30">
       <div className="w-[80%]">
-        <button onClick={closeTimerModal} className="w-full flex justify-end text-white text-h6 px-2 my-2">
-          닫기 X
+        <button onClick={closeTimerModal} className="w-full flex items-center justify-end text-white text-h6 px-2 my-2">
+          닫기 <CancleIcon />
         </button>
         <div className="p-5 bg-white rounded-[32px] flex flex-col gap-y-6">
           <div className="flex flex-col gap-y-4">
@@ -67,3 +67,27 @@ const TimerModal: React.FC<SessionModalProps> = ({
 };
 
 export default TimerModal;
+
+const CancleIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} fill="none" {...props}>
+    <mask
+      id="a"
+      width={24}
+      height={24}
+      x={0}
+      y={0}
+      maskUnits="userSpaceOnUse"
+      style={{
+        maskType: 'alpha',
+      }}>
+      <path fill="#D9D9D9" d="M0 0h24v24H0z" />
+    </mask>
+    <g mask="url(#a)">
+      <path
+        fill="#fff"
+        d="m12 12.708-5.246 5.246a.5.5 0 0 1-.344.15.47.47 0 0 1-.364-.15.5.5 0 0 1-.16-.354.5.5 0 0 1 .16-.354L11.292 12 6.046 6.754a.5.5 0 0 1-.15-.344.47.47 0 0 1 .15-.364.5.5 0 0 1 .354-.16.5.5 0 0 1 .354.16L12 11.292l5.246-5.246a.5.5 0 0 1 .344-.15.47.47 0 0 1 .364.15.5.5 0 0 1 .16.354.5.5 0 0 1-.16.354L12.708 12l5.246 5.246a.5.5 0 0 1 .15.344.47.47 0 0 1-.15.364.5.5 0 0 1-.354.16.5.5 0 0 1-.354-.16z"
+      />
+    </g>
+  </svg>
+);
+

--- a/src/components/exam/YearSelector.tsx
+++ b/src/components/exam/YearSelector.tsx
@@ -6,11 +6,16 @@ import * as React from 'react';
 import MockExamYearsFilter from '@/components/exam/MockExamYearsFilter';
 import useGetMockExamYears from '@/lib/hooks/useGetMockExamYears';
 
+interface Props {
+  examYears: number[];
+  isClickedYearSelector: boolean;
+  setIsClickedYearSelector: React.Dispatch<React.SetStateAction<boolean>>;
+  selectedYear: number;
+  setSelectedYear: React.Dispatch<React.SetStateAction<number>>;
+}
 // 과목의 Year를 선택하는 모듈
-const YearSelector = () => {
-  const { examYears } = useGetMockExamYears('YearSelector');
-  const [isClickedYearSelector, setIsClickedYearSelector] = useState<boolean>(false);
-  const [selectedYear, setSelectedYear] = useState<number>(2017);
+const YearSelector = (props: Props) => {
+  const { examYears, isClickedYearSelector, setSelectedYear, setIsClickedYearSelector, selectedYear } = props;
 
   return (
     <>

--- a/src/components/exam/YearSelector.tsx
+++ b/src/components/exam/YearSelector.tsx
@@ -1,60 +1,47 @@
 'use client';
-import React, { useEffect } from 'react';
-import { useRecoilState } from 'recoil';
 
-import { useGetExamInfoData } from '@/lib/hooks/ExamInfoFetcher';
-import { examYearList } from '@/types/global';
-import { YearState } from '@/utils/recoilState';
+import { SVGProps, useState } from 'react';
+import * as React from 'react';
+
+import MockExamYearsFilter from '@/components/exam/MockExamYearsFilter';
+import useGetMockExamYears from '@/lib/hooks/useGetMockExamYears';
 
 // 과목의 Year를 선택하는 모듈
-const YearSelector = ({}) => {
-  // 과목의 연도의 상태를 관리하는 state
-  const [selectedYear, setSelectedYear] = useRecoilState<Number | undefined>(YearState);
-  const { Data } = useGetExamInfoData();
-
-  // year정보만 추출하기
-  // const yearKeys = Object.keys(Data?.result?.examYearWithRounds || {});
-  const yearKeys = ['2020', '2021', '2023'];
-  // 추출한 데이터 정수형으로 변환하기
-  const yearsAsIntegers = yearKeys.map((year) => parseInt(year, 10));
-
-  // 연도 리스트가 들어간거임
-  const examYears: examYearList = {
-    years: yearsAsIntegers,
-  };
-
-  // 받아온 연도에 첫번째로 set
-  const defaultYear = examYears.years[0] || undefined;
-
-  // selectbox에 들어갈 년도 배열 정립
-  const uniqueYears = examYears.years || null;
-
-  useEffect(() => {
-    setSelectedYear(defaultYear);
-  }, [setSelectedYear, defaultYear]);
-
-  // 연도 변경하여 상태에 저장하는 함수
-  const handleSubjectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const selectedYear = parseInt(event.target.value, 10);
-    setSelectedYear(selectedYear);
-  };
+const YearSelector = () => {
+  const { examYears } = useGetMockExamYears('YearSelector');
+  const [isClickedYearSelector, setIsClickedYearSelector] = useState<boolean>(false);
+  const [selectedYear, setSelectedYear] = useState<number>(2017);
 
   return (
-    <div className="mt-2">
-      <select
-        id="subject"
-        name="subject"
-        value={selectedYear?.toString() || ''}
-        onChange={handleSubjectChange}
-        className="mx-auto mt-1 text-h4 font-bold block w-[95%] p-3 bg-gray0 rounded-xl shadow-sm focus:outline-none focus:ring focus:border-blue-300 sm:text-sm">
-        {uniqueYears.map((year, index) => (
-          <option key={index} value={year}>
-            {year}년 기출 모의고사
-          </option>
-        ))}
-      </select>
-    </div>
+    <>
+      <div
+        onClick={() => {
+          setIsClickedYearSelector(!isClickedYearSelector);
+        }}
+        className={'mt-2 flex justify-between items-center bg-gray0 rounded-[16px] py-3 px-4'}>
+        <span>{selectedYear}년도 기출 모의고사</span>
+        {isClickedYearSelector ? <ActiveIcon /> : <DisableIcon />}
+      </div>
+      {isClickedYearSelector ? (
+        <MockExamYearsFilter
+          setIsClickedYearSelector={setIsClickedYearSelector}
+          setSelectedYear={setSelectedYear}
+          yearList={examYears}
+        />
+      ) : null}
+    </>
   );
 };
 
 export default YearSelector;
+
+const DisableIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={20} height={20} fill="none" {...props}>
+    <path stroke="#000" strokeLinecap="round" d="m13.5 8.5-3.5 3-3.5-3" />
+  </svg>
+);
+const ActiveIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={20} height={20} fill="none" {...props}>
+    <path stroke="#000" strokeLinecap="round" d="m6.5 11.5 3.5-3 3.5 3" />
+  </svg>
+);

--- a/src/hooks/useCalculateScore.tsx
+++ b/src/hooks/useCalculateScore.tsx
@@ -7,10 +7,10 @@ import { SubjectResultRequests, UserAnswerRequests } from '@/types/global';
 /**
  * 채점해주는 커스텀 훅
  */
-const useCalculateScore = () => {
+const useCalculateScore = (mockExamId: number) => {
   const [userAnswerList, setUserAnswerList] = useRecoilState<UserAnswerRequests[]>(userAnswerRequestsList);
   const [subjectResultList, setSubjectResultList] = useRecoilState(subjectResultRequestsList);
-  const { questions, isLoading, isError } = useMockExamQuestions();
+  const { questions, isLoading, isError } = useMockExamQuestions(mockExamId);
 
   /**
    * 사용자가 선택한 각 선택지가 맞았는지 틀렸는지 채점

--- a/src/lib/api/exam.ts
+++ b/src/lib/api/exam.ts
@@ -1,7 +1,10 @@
 import { sendRequest } from '@/lib/axios';
 import { SubjectResultRequests } from '@/types/global';
 
-export const postSubjectResultRequestsList = async (subjectResultRequestsList: SubjectResultRequests[]) => {
+export const postSubjectResultRequestsList = async (
+  subjectResultRequestsList: SubjectResultRequests[],
+  mockExamId: number,
+) => {
   try {
     // 액세스 토큰을 헤더에 담아 요청 보내기
     const response = await sendRequest({
@@ -10,7 +13,7 @@ export const postSubjectResultRequestsList = async (subjectResultRequestsList: S
       },
       method: 'POST',
       data: { createSubjectResultRequests: subjectResultRequestsList },
-      url: 'mock-exams/1/mock-exam-results',
+      url: `mock-exams/${mockExamId}/mock-exam-results`,
     });
     // 성공적인 응답 처리
     return response.data;

--- a/src/lib/hooks/ExamInfoFetcher.ts
+++ b/src/lib/hooks/ExamInfoFetcher.ts
@@ -1,4 +1,3 @@
-import { AxiosResponse } from 'axios';
 import useSWR from 'swr';
 
 import { client, swrGetFetcher } from '@/lib/axios';

--- a/src/lib/hooks/useGetExamResultRecent.tsx
+++ b/src/lib/hooks/useGetExamResultRecent.tsx
@@ -1,0 +1,18 @@
+import useSWR from 'swr';
+
+import { swrGetFetcher } from '@/lib/axios';
+import { RecentMockExamResultResponseType } from '@/types/exam/type';
+
+const useGetExamResultRecent = (mockExamId: number) => {
+  const { data, error } = useSWR<RecentMockExamResultResponseType>(
+    `/mock-exams/${mockExamId}/mock-exam-results/recent`,
+    swrGetFetcher,
+  );
+
+  return {
+    examResultRecent: data ? data.result : false,
+    isLoading: !error && !data,
+    isError: error,
+  };
+};
+export default useGetExamResultRecent;

--- a/src/lib/hooks/useGetExamResults.tsx
+++ b/src/lib/hooks/useGetExamResults.tsx
@@ -1,0 +1,17 @@
+import useSWR from 'swr';
+
+import { swrGetFetcher } from '@/lib/axios';
+import { MockExamResultsResponseType, MockExamResultType } from '@/types/exam/type';
+
+const useGetExamResults = (mockExamId: number) => {
+  const { data, error } = useSWR<MockExamResultsResponseType>(`/mock-exams/${mockExamId}`, swrGetFetcher);
+
+  const parseResultList = data?.result.map((item: MockExamResultType) => item).flat();
+
+  return {
+    examResults: data ? parseResultList : null,
+    isLoading: !error && !data,
+    isError: error,
+  };
+};
+export default useGetExamResults;

--- a/src/lib/hooks/useGetMockExamYears.tsx
+++ b/src/lib/hooks/useGetMockExamYears.tsx
@@ -1,14 +1,18 @@
 import { AxiosResponse } from 'axios';
+import { useEffect } from 'react';
 import useSWR from 'swr';
 
 import { swrGetFetcher } from '@/lib/axios';
-import { useEffect } from 'react';
 
-const useGetMockExamYears = () => {
+const useGetMockExamYears = (usage: string) => {
   const { data, error } = useSWR<AxiosResponse>('/certificates/1/exam-years', swrGetFetcher);
 
+  /**
+   * 사용된 컴포넌트에 따라 초기화 값을 다르게 하도록 하는 트릭
+   * CommentaryBoardList 일 때만 전체가 초기화 되도록 구현
+   */
   useEffect(() => {
-    if (data && Array.isArray(data?.result) && !data?.result.includes('전체')) {
+    if (usage == 'CommentaryBoardList' && data && Array.isArray(data?.result) && !data?.result.includes('전체')) {
       data.result.unshift('전체');
     }
   }, [data]);

--- a/src/lib/hooks/useGetMockExams.tsx
+++ b/src/lib/hooks/useGetMockExams.tsx
@@ -6,7 +6,7 @@ import { swrGetFetcher } from '@/lib/axios';
 const useGetMockExams = (certificateId: number, year: number | string) => {
   const { data, error } = useSWR<AxiosResponse>(
     year === '전체'
-      ? `/certificates/${certificateId}/mock-exams?examYear=2023`
+      ? `/certificates/${certificateId}/mock-exams?examYear=2017`
       : `/certificates/${certificateId}/mock-exams?examYear=${year}`,
     swrGetFetcher,
   );

--- a/src/lib/hooks/useMockExamQuestions.tsx
+++ b/src/lib/hooks/useMockExamQuestions.tsx
@@ -4,8 +4,8 @@ import useSWR from 'swr';
 import { swrGetFetcher } from '@/lib/axios';
 import { Certificate, QuestionsResponse } from '@/types/global';
 
-const useGetGoalSettingData = () => {
-  const { data, error } = useSWR<AxiosResponse>('/mock-exams/1/questions', swrGetFetcher);
+const useGetGoalSettingData = (mockExamId: number) => {
+  const { data, error } = useSWR<AxiosResponse>(`/mock-exams/${mockExamId}/questions`, swrGetFetcher);
 
   const parseResultList: QuestionsResponse[] = data?.result.map((item) => item).flat();
 

--- a/src/recoil/exam/atom.ts
+++ b/src/recoil/exam/atom.ts
@@ -72,3 +72,8 @@ export const mockExamIdState = atom<number>({
   key: 'mockExamIdState',
   default: 1,
 });
+
+export const timeLimitState = atom<number>({
+  key: 'timeLimitState',
+  default: 0,
+});

--- a/src/recoil/exam/atom.ts
+++ b/src/recoil/exam/atom.ts
@@ -37,6 +37,11 @@ export let userAnswerRequestsList = atom<UserAnswerRequests[]>({
   default: [],
 });
 
+export const sessionRecordedState = atom<boolean>({
+  key: 'sessionRecordedState',
+  default: false,
+});
+
 export const questionIndex = atom<number>({
   key: 'questionIndex',
   default: 0,

--- a/src/recoil/exam/atom.ts
+++ b/src/recoil/exam/atom.ts
@@ -61,3 +61,9 @@ export const stopwatchIsPaused = atom<boolean>({
   key: 'stopwatchIsPaused',
   default: false,
 });
+
+//모의고사 응시 번호
+export const mockExamIdState = atom<number>({
+  key: 'mockExamIdState',
+  default: 1,
+});

--- a/src/types/exam/type.ts
+++ b/src/types/exam/type.ts
@@ -1,0 +1,12 @@
+import { ReviewIncorrectMockExam } from '@/types/global';
+export interface RecentMockExamResultResponseType {
+  responseCode: string;
+  result: RecentMockExamResultType
+}
+interface RecentMockExamResultType {
+  mockExamResultId: number;
+  round: number;
+  mockExam: ReviewIncorrectMockExam;
+  totalScore: number;
+  createdAt: string;
+}

--- a/src/types/exam/type.ts
+++ b/src/types/exam/type.ts
@@ -1,7 +1,7 @@
-import { ReviewIncorrectMockExam } from '@/types/global';
+import { ReviewIncorrectMockExam, Subject } from '@/types/global';
 export interface RecentMockExamResultResponseType {
   responseCode: string;
-  result: RecentMockExamResultType
+  result: RecentMockExamResultType;
 }
 interface RecentMockExamResultType {
   mockExamResultId: number;
@@ -9,4 +9,25 @@ interface RecentMockExamResultType {
   mockExam: ReviewIncorrectMockExam;
   totalScore: number;
   createdAt: string;
+}
+
+export interface MockExamResultsResponseType {
+  responseCode: string;
+  result: MockExamResultType[];
+}
+
+export interface MockExamResultType {
+  mockExamResultId: number;
+  round: number;
+  mockExam: ReviewIncorrectMockExam;
+  subjectResults: SubjectResultsType[];
+  totalScore: number;
+}
+
+interface SubjectResultsType {
+  subject: Subject;
+  score: number;
+  numberOfCorrect: number;
+  totalTakenTime: number;
+  correctRate: number;
 }


### PR DESCRIPTION
Closes #113 
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

- 모의고사 응시 시험 홈페이지 api 연결하였습니다.
- 기존에 style이 안맞는 부분 조금 수정했습니다.
- 년도 필터를 웹에서 제공하는 태그를 사용하지 않고 구현하였습니다.
- 모의고사 응시 화면과 연결하였습니다.
- 기존에 제출되지 않은 모의고사 에러를 해결하였습니다. 

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

## 😭 어려웠던 점

제출하는 부분에 있어서 에러가 발생했는데 여러 트릭으로 제출되는 로직이라 하나가 이상하니 다 변경되어야 해서 시간이 조금 걸렸습니다.
모달창에서 회차를 변경하면 이에 따라 값이 변경되어야 하는데 그건.. 아직 못했습니다(props로 내려받게 해야 합니다.)
