### PR TITLE
[#116] 모의고사 결과 페이지 기능 구현 

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,12 +5,18 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/lib/hooks/useGetExamResults.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/Question.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/Question.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectGradeCard.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectGradeCard.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/types/exam/type.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/types/exam/type.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SubmitConfirmationModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubmitConfirmationModal.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/TimerModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TimerModal.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/hooks/useCalculateScore.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/hooks/useCalculateScore.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/lib/api/exam.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/api/exam.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/lib/hooks/useMockExamQuestions.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/useMockExamQuestions.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/recoil/exam/atom.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/recoil/exam/atom.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -120,7 +126,7 @@
       <workItem from="1715506546722" duration="28839000" />
       <workItem from="1715652288664" duration="122000" />
       <workItem from="1716123590906" duration="891000" />
-      <workItem from="1716256789152" duration="15085000" />
+      <workItem from="1716256789152" duration="18991000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,15 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/components/exam/TakenTimeGraphReport.tsx" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/components/exam/IncorrectQuestions.tsx" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/lib/hooks/useGetIncorrectQuestionsResult.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/(main)/exam/result/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/(main)/exam/result/page.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/Question.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/Question.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/TakenTimeGraphReport.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TakenTimeGraphReport.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/types/exam/type.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/types/exam/type.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/types/global.d.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/types/global.d.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -28,22 +34,22 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "git-widget-placeholder": "feature-mock__exam__results",
-    "last_opened_file_path": "/Users/hwang-yulim/Documents/GitHub/cercat-front",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "settings.editor.selected.configurable": "preferences.editor",
-    "ts.external.directory.path": "/Users/hwang-yulim/Documents/GitHub/cercat-front/node_modules/typescript/lib",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;feature-mock__exam__results&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/Users/hwang-yulim/Documents/GitHub/cercat-front&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.editor&quot;,
+    &quot;ts.external.directory.path&quot;: &quot;/Users/hwang-yulim/Documents/GitHub/cercat-front/node_modules/typescript/lib&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/public" />
@@ -117,7 +123,8 @@
       <workItem from="1715506546722" duration="28839000" />
       <workItem from="1715652288664" duration="122000" />
       <workItem from="1716123590906" duration="891000" />
-      <workItem from="1716256789152" duration="33930000" />
+      <workItem from="1716256789152" duration="35566000" />
+      <workItem from="1716426429072" duration="3057000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,15 +5,13 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/components/exam/IncorrectQuestions.tsx" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/lib/hooks/useGetIncorrectQuestionsResult.tsx" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/lib/hooks/AccuracyChart.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/package-lock.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/(main)/exam/result/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/(main)/exam/result/page.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/Question.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/Question.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/TakenTimeGraphReport.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TakenTimeGraphReport.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/IncorrectQuestions.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/IncorrectQuestions.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/types/exam/type.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/types/exam/type.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/types/global.d.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/types/global.d.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -124,7 +122,8 @@
       <workItem from="1715652288664" duration="122000" />
       <workItem from="1716123590906" duration="891000" />
       <workItem from="1716256789152" duration="35566000" />
-      <workItem from="1716426429072" duration="3057000" />
+      <workItem from="1716426429072" duration="10065000" />
+      <workItem from="1716450504992" duration="7559000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,10 +5,10 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/TimerModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TimerModal.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/recoil/exam/atom.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/recoil/exam/atom.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -118,7 +118,7 @@
       <workItem from="1715506546722" duration="28839000" />
       <workItem from="1715652288664" duration="122000" />
       <workItem from="1716123590906" duration="891000" />
-      <workItem from="1716256789152" duration="24974000" />
+      <workItem from="1716256789152" duration="25541000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,15 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/src/components/exam/MockExamYearsFilter.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/lib/api/community.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/api/community.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/(main)/exam/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/(main)/exam/page.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/common/Banner.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/common/Banner.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/community/CommentaryBoardList.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/community/CommentaryBoardList.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/community/EditPost.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/community/EditPost.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/community/WriteExplanationPost.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/community/WriteExplanationPost.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/YearSelector.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/YearSelector.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/lib/hooks/useGetMockExamYears.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/useGetMockExamYears.tsx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -27,22 +34,22 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;feature-review__board__list&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/Users/hwang-yulim/Documents/GitHub/cercat-front&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.editor&quot;,
-    &quot;ts.external.directory.path&quot;: &quot;/Users/hwang-yulim/Documents/GitHub/cercat-front/node_modules/typescript/lib&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "git-widget-placeholder": "feature-mock__test__home__api",
+    "last_opened_file_path": "/Users/hwang-yulim/Documents/GitHub/cercat-front",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "preferences.editor",
+    "ts.external.directory.path": "/Users/hwang-yulim/Documents/GitHub/cercat-front/node_modules/typescript/lib",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/public" />
@@ -116,6 +123,7 @@
       <workItem from="1715506546722" duration="28839000" />
       <workItem from="1715652288664" duration="122000" />
       <workItem from="1716123590906" duration="891000" />
+      <workItem from="1716256789152" duration="4606000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,10 +5,16 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/components/exam/MockExamReportHeader.tsx" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/components/exam/MockExamResultReport.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/(main)/exam/result/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/(main)/exam/result/page.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectGradeCard.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectGradeCard.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/lib/hooks/useGetExamResults.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/useGetTestResults.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/recoil/exam/atom.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/recoil/exam/atom.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/types/exam/type.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/types/exam/type.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -29,22 +35,22 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;feature-mock__test__home__api&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/Users/hwang-yulim/Documents/GitHub/cercat-front&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.editor&quot;,
-    &quot;ts.external.directory.path&quot;: &quot;/Users/hwang-yulim/Documents/GitHub/cercat-front/node_modules/typescript/lib&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "git-widget-placeholder": "feature-mock__exam__results",
+    "last_opened_file_path": "/Users/hwang-yulim/Documents/GitHub/cercat-front",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "preferences.editor",
+    "ts.external.directory.path": "/Users/hwang-yulim/Documents/GitHub/cercat-front/node_modules/typescript/lib",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/public" />
@@ -118,7 +124,7 @@
       <workItem from="1715506546722" duration="28839000" />
       <workItem from="1715652288664" duration="122000" />
       <workItem from="1716123590906" duration="891000" />
-      <workItem from="1716256789152" duration="25541000" />
+      <workItem from="1716256789152" duration="32550000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,16 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/components/exam/MockExamReportHeader.tsx" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/components/exam/MockExamResultReport.tsx" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/components/exam/TakenTimeGraphReport.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/(main)/exam/result/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/(main)/exam/result/page.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectGradeCard.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectGradeCard.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/lib/hooks/useGetExamResults.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/useGetTestResults.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/recoil/exam/atom.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/recoil/exam/atom.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/types/exam/type.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/types/exam/type.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -124,7 +117,7 @@
       <workItem from="1715506546722" duration="28839000" />
       <workItem from="1715652288664" duration="122000" />
       <workItem from="1716123590906" duration="891000" />
-      <workItem from="1716256789152" duration="32550000" />
+      <workItem from="1716256789152" duration="33930000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,15 +5,12 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/lib/hooks/useGetExamResultRecent.tsx" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/types/exam/type.ts" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/lib/hooks/useGetExamResults.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/(main)/exam/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/(main)/exam/page.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/YearSelector.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/YearSelector.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/lib/hooks/ExamInfoFetcher.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/ExamInfoFetcher.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/lib/hooks/useGetMockExams.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/useGetMockExams.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectGradeCard.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectGradeCard.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/types/exam/type.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/types/exam/type.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -123,7 +120,7 @@
       <workItem from="1715506546722" duration="28839000" />
       <workItem from="1715652288664" duration="122000" />
       <workItem from="1716123590906" duration="891000" />
-      <workItem from="1716256789152" duration="9098000" />
+      <workItem from="1716256789152" duration="15085000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,10 +6,9 @@
   <component name="ChangeListManager">
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/Question.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/Question.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/SubmitConfirmationModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubmitConfirmationModal.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/recoil/exam/atom.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/recoil/exam/atom.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/TimerModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TimerModal.tsx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -30,22 +29,22 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "git-widget-placeholder": "feature-mock__test__home__api",
-    "last_opened_file_path": "/Users/hwang-yulim/Documents/GitHub/cercat-front",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "settings.editor.selected.configurable": "preferences.editor",
-    "ts.external.directory.path": "/Users/hwang-yulim/Documents/GitHub/cercat-front/node_modules/typescript/lib",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;feature-mock__test__home__api&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/Users/hwang-yulim/Documents/GitHub/cercat-front&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.editor&quot;,
+    &quot;ts.external.directory.path&quot;: &quot;/Users/hwang-yulim/Documents/GitHub/cercat-front/node_modules/typescript/lib&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/public" />
@@ -119,7 +118,7 @@
       <workItem from="1715506546722" duration="28839000" />
       <workItem from="1715652288664" duration="122000" />
       <workItem from="1716123590906" duration="891000" />
-      <workItem from="1716256789152" duration="23876000" />
+      <workItem from="1716256789152" duration="24974000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,13 +5,13 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/lib/hooks/AccuracyChart.tsx" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/components/exam/UserExamAttemptsFilter.tsx" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/components/exam/UserExamAttemptsFilterContent.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/package-lock.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/(main)/exam/result/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/(main)/exam/result/page.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/IncorrectQuestions.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/IncorrectQuestions.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/types/exam/type.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/types/exam/type.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/lib/hooks/AccuracyChart.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/AccuracyChart.tsx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -123,7 +123,8 @@
       <workItem from="1716123590906" duration="891000" />
       <workItem from="1716256789152" duration="35566000" />
       <workItem from="1716426429072" duration="10065000" />
-      <workItem from="1716450504992" duration="7559000" />
+      <workItem from="1716450504992" duration="9437000" />
+      <workItem from="1716709779130" duration="6226000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,13 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/components/exam/UserExamAttemptsFilter.tsx" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/components/exam/UserExamAttemptsFilterContent.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/(main)/exam/result/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/(main)/exam/result/page.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/IncorrectQuestions.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/IncorrectQuestions.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/lib/hooks/AccuracyChart.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/AccuracyChart.tsx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -124,7 +118,7 @@
       <workItem from="1716256789152" duration="35566000" />
       <workItem from="1716426429072" duration="10065000" />
       <workItem from="1716450504992" duration="9437000" />
-      <workItem from="1716709779130" duration="6226000" />
+      <workItem from="1716709779130" duration="6606000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -7,15 +7,8 @@
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/Question.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/Question.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SessionModal.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/SubmitConfirmationModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubmitConfirmationModal.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TestSubmitOrCancle.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/exam/TimerModal.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/TimerModal.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/hooks/useCalculateScore.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/hooks/useCalculateScore.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/lib/api/exam.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/api/exam.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/lib/hooks/useMockExamQuestions.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/useMockExamQuestions.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/recoil/exam/atom.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/recoil/exam/atom.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -126,7 +119,7 @@
       <workItem from="1715506546722" duration="28839000" />
       <workItem from="1715652288664" duration="122000" />
       <workItem from="1716123590906" duration="891000" />
-      <workItem from="1716256789152" duration="18991000" />
+      <workItem from="1716256789152" duration="23876000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,15 +5,15 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04137b8a-1737-4fb7-bb7a-17b33d146a9e" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/components/exam/MockExamYearsFilter.tsx" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/lib/hooks/useGetExamResultRecent.tsx" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/types/exam/type.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/(main)/exam/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/(main)/exam/page.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/common/Banner.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/common/Banner.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/community/CommentaryBoardList.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/community/CommentaryBoardList.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/community/EditPost.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/community/EditPost.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/community/WriteExplanationPost.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/community/WriteExplanationPost.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectCard.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/SubjectList.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/exam/YearSelector.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/exam/YearSelector.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/lib/hooks/useGetMockExamYears.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/useGetMockExamYears.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/lib/hooks/ExamInfoFetcher.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/ExamInfoFetcher.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/lib/hooks/useGetMockExams.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/hooks/useGetMockExams.tsx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -123,7 +123,7 @@
       <workItem from="1715506546722" duration="28839000" />
       <workItem from="1715652288664" duration="122000" />
       <workItem from="1716123590906" duration="891000" />
-      <workItem from="1716256789152" duration="4606000" />
+      <workItem from="1716256789152" duration="9098000" />
     </task>
     <servers />
   </component>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "cos-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@nivo/core": "^0.87.0",
         "@nivo/radar": "^0.85.1",
         "axios": "^1.6.5",
         "chart.js": "^4.4.2",
+        "d3-shape": "^3.2.0",
         "date-fns": "^3.2.0",
         "dayjs": "^1.11.10",
         "gsap": "^3.12.5",
@@ -395,7 +397,7 @@
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
-    "node_modules/@nivo/core": {
+    "node_modules/@nivo/colors/node_modules/@nivo/core": {
       "version": "0.85.1",
       "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.85.1.tgz",
       "integrity": "sha512-366bc4hBicsitcinQyKGfUPpifk5W60RAjwZ4sQkY8R6OzwPMgY+eu/sfPZTNcY7rsleGg8whX0A2dBg2czWMA==",
@@ -422,6 +424,65 @@
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
+    "node_modules/@nivo/colors/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/@nivo/colors/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/@nivo/core": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.87.0.tgz",
+      "integrity": "sha512-yEQWJn7QjWnbmCZccBCo4dligNyNyz3kgyV9vEtcaB1iGeKhg55RJEAlCOul+IDgSCSPFci2SxTmipE6LZEZCg==",
+      "dependencies": {
+        "@nivo/tooltip": "0.87.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-shape": "^3.1.6",
+        "d3-color": "^3.1.0",
+        "d3-format": "^1.4.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "d3-shape": "^3.2.0",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nivo/donate"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
+    "node_modules/@nivo/core/node_modules/@nivo/tooltip": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.87.0.tgz",
+      "integrity": "sha512-nZJWyRIt/45V/JBdJ9ksmNm1LFfj59G1Dy9wB63Icf2YwyBT+J+zCzOGXaY7gxCxgF1mnSL3dC7fttcEdXyN/g==",
+      "dependencies": {
+        "@nivo/core": "0.87.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
+    "node_modules/@nivo/core/node_modules/@types/d3-shape": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
     "node_modules/@nivo/legends": {
       "version": "0.85.1",
       "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.85.1.tgz",
@@ -436,6 +497,46 @@
       },
       "peerDependencies": {
         "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
+    "node_modules/@nivo/legends/node_modules/@nivo/core": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.85.1.tgz",
+      "integrity": "sha512-366bc4hBicsitcinQyKGfUPpifk5W60RAjwZ4sQkY8R6OzwPMgY+eu/sfPZTNcY7rsleGg8whX0A2dBg2czWMA==",
+      "dependencies": {
+        "@nivo/recompose": "0.85.0",
+        "@nivo/tooltip": "0.85.1",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-shape": "^2.0.0",
+        "d3-color": "^3.1.0",
+        "d3-format": "^1.4.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "d3-shape": "^1.3.5",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nivo/donate"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
+    "node_modules/@nivo/legends/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/@nivo/legends/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
       }
     },
     "node_modules/@nivo/radar": {
@@ -455,6 +556,46 @@
       },
       "peerDependencies": {
         "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
+    "node_modules/@nivo/radar/node_modules/@nivo/core": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.85.1.tgz",
+      "integrity": "sha512-366bc4hBicsitcinQyKGfUPpifk5W60RAjwZ4sQkY8R6OzwPMgY+eu/sfPZTNcY7rsleGg8whX0A2dBg2czWMA==",
+      "dependencies": {
+        "@nivo/recompose": "0.85.0",
+        "@nivo/tooltip": "0.85.1",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-shape": "^2.0.0",
+        "d3-color": "^3.1.0",
+        "d3-format": "^1.4.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "d3-shape": "^1.3.5",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nivo/donate"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
+    "node_modules/@nivo/radar/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/@nivo/radar/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
       }
     },
     "node_modules/@nivo/recompose": {
@@ -481,6 +622,46 @@
       },
       "peerDependencies": {
         "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
+    "node_modules/@nivo/tooltip/node_modules/@nivo/core": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.85.1.tgz",
+      "integrity": "sha512-366bc4hBicsitcinQyKGfUPpifk5W60RAjwZ4sQkY8R6OzwPMgY+eu/sfPZTNcY7rsleGg8whX0A2dBg2czWMA==",
+      "dependencies": {
+        "@nivo/recompose": "0.85.0",
+        "@nivo/tooltip": "0.85.1",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-shape": "^2.0.0",
+        "d3-color": "^3.1.0",
+        "d3-format": "^1.4.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "d3-shape": "^1.3.5",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nivo/donate"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
+    "node_modules/@nivo/tooltip/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/@nivo/tooltip/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1703,9 +1884,12 @@
       }
     },
     "node_modules/d3-path": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",
@@ -1735,11 +1919,14 @@
       }
     },
     "node_modules/d3-shape": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
       "dependencies": {
-        "d3-path": "1"
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-time": {
@@ -5931,25 +6118,6 @@
       "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
       "dependencies": {
         "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "dependencies": {
-        "d3-path": "^3.1.0"
       },
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "lint": "eslint --fix '**/*.{ts,tsx}'"
   },
   "dependencies": {
+    "@nivo/core": "^0.87.0",
     "@nivo/radar": "^0.85.1",
     "axios": "^1.6.5",
     "chart.js": "^4.4.2",
+    "d3-shape": "^3.2.0",
     "date-fns": "^3.2.0",
     "dayjs": "^1.11.10",
     "gsap": "^3.12.5",

--- a/src/app/(main)/exam/page.tsx
+++ b/src/app/(main)/exam/page.tsx
@@ -1,20 +1,28 @@
-import React from 'react';
+'use client';
+import React, { useState } from 'react';
 
 import Banner from '@/components/common/Banner';
 import Header from '@/components/common/Header';
 import SubjectSessionCard from '@/components/exam/SubjectList';
 import YearSelector from '@/components/exam/YearSelector';
+import useGetMockExamYears from '@/lib/hooks/useGetMockExamYears';
+import NavBar from '@/components/common/NavBar';
 
 const Exam = () => {
   return (
     <div>
       <Header />
       <SolveExamBox />
+      <NavBar />
     </div>
   );
 };
 
 const SolveExamBox = () => {
+  const { examYears } = useGetMockExamYears('YearSelector');
+  const [isClickedYearSelector, setIsClickedYearSelector] = useState<boolean>(false);
+  const [selectedYear, setSelectedYear] = useState<number>(2017);
+
   return (
     <div>
       <div className="px-5 py-4">
@@ -23,8 +31,14 @@ const SolveExamBox = () => {
           <Banner title="실제 출제된 문제를 모아봤어요." buttonText="랜덤 모의고사" href="/exam/wrong" />
         </div>
         <div className="text-h3 mt-[24px] font-bold">모의고사 풀기</div>
-        <YearSelector />
-        <SubjectSessionCard />
+        <YearSelector
+          isClickedYearSelector={isClickedYearSelector}
+          examYears={examYears}
+          setSelectedYear={setSelectedYear}
+          setIsClickedYearSelector={setIsClickedYearSelector}
+          selectedYear={selectedYear}
+        />
+        <SubjectSessionCard selectedYear={selectedYear} />
       </div>
     </div>
   );

--- a/src/app/(main)/exam/page.tsx
+++ b/src/app/(main)/exam/page.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 
 import Banner from '@/components/common/Banner';
 import Header from '@/components/common/Header';
-import NavBar from '@/components/common/NavBar';
-import WrongQuestionsSummaryBox from '@/components/exam/IncorrectQuestionSummaryCard';
 import SubjectSessionCard from '@/components/exam/SubjectList';
 import YearSelector from '@/components/exam/YearSelector';
 
@@ -19,12 +17,12 @@ const Exam = () => {
 const SolveExamBox = () => {
   return (
     <div>
-      <div className="w-[90%] mx-auto">
-        <div className="w-[95%] flex mx-auto space-x-1">
+      <div className="px-5 py-4">
+        <div className="flex gap-x-4 justify-between">
           <Banner title="지금까지 틀린 문제만 모아봤어요." buttonText="틀린 문제 풀기" href="/exam/wrong" />
-          <Banner title="실제 출제된 문제를 모아봤어요" buttonText="랜덤 모의고사" href="/exam/wrong" />
+          <Banner title="실제 출제된 문제를 모아봤어요." buttonText="랜덤 모의고사" href="/exam/wrong" />
         </div>
-        <div className="w-[90%] mx-auto font-black text-h4 mt-5">모의고사 풀기</div>
+        <div className="text-h3 mt-[24px] font-bold">모의고사 풀기</div>
         <YearSelector />
         <SubjectSessionCard />
       </div>

--- a/src/app/(main)/exam/result/page.tsx
+++ b/src/app/(main)/exam/result/page.tsx
@@ -45,7 +45,7 @@ const Result = () => {
    * ExamResults 리스트의 값이 1개 이상일 경우 필터 적용 1개일 경우는 적용 X
    * @param examResults 시험 결과
    */
-  const displayComponentBasedOnExamResults = (examResults: MockExamResultType[] | null) => {
+  const displayComponentBasedOnExamResults = (examResults: MockExamResultType[] | null | undefined) => {
     if (examResults && examResults.length === 1) {
       return (
         <>

--- a/src/app/(main)/exam/result/page.tsx
+++ b/src/app/(main)/exam/result/page.tsx
@@ -7,9 +7,10 @@ import NavBar from '@/components/common/NavBar';
 import CorrectRateGraph from '@/components/exam/CorrectRateGraph';
 import MockExamReportHeader from '@/components/exam/MockExamReportHeader';
 import MockExamResultReport from '@/components/exam/MockExamResultReport';
+import TakenTimeGraphReport from '@/components/exam/TakenTimeGraphReport';
 import useGetTestResults from '@/lib/hooks/useGetTestResults';
 import { mockExamIdState, submittedMockExamResultIdState } from '@/recoil/exam/atom';
-import TakenTimeGraphReport from '@/components/exam/TakenTimeGraphReport';
+import IncorrectQuestions from '@/components/exam/IncorrectQuestions';
 
 const Result = () => {
   const [submittedMockExamResultId, setSubmittedMockExamResultId] = useRecoilState(submittedMockExamResultIdState);
@@ -52,7 +53,7 @@ const Result = () => {
         ) : (
           <div>
             <div>
-              틀린문제
+              <IncorrectQuestions />
             </div>
           </div>
         )}

--- a/src/app/(main)/exam/result/page.tsx
+++ b/src/app/(main)/exam/result/page.tsx
@@ -1,29 +1,38 @@
 'use client';
-import { ResponsiveRadar } from '@nivo/radar';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 
 import Header from '@/components/common/Header';
 import NavBar from '@/components/common/NavBar';
-import CorrectRateGraph from '@/components/exam/CorrectRateGraph';
 import IncorrectQuestions from '@/components/exam/IncorrectQuestions';
 import MockExamReportHeader from '@/components/exam/MockExamReportHeader';
 import MockExamResultReport from '@/components/exam/MockExamResultReport';
 import TakenTimeGraphReport from '@/components/exam/TakenTimeGraphReport';
+import UserExamAttemptsFilterContent from '@/components/exam/UserExamAttemptsFilterContent';
+import AccuracyChart from '@/lib/hooks/AccuracyChart';
 import useGetTestResults from '@/lib/hooks/useGetTestResults';
 import { mockExamIdState, submittedMockExamResultIdState } from '@/recoil/exam/atom';
-import { subjectData } from '@/utils/common/accuracyChart';
-import AccuracyChart from '@/lib/hooks/AccuracyChart';
+import { MockExamResultType } from '@/types/exam/type';
 
 const Result = () => {
   const [submittedMockExamResultId, setSubmittedMockExamResultId] = useRecoilState(submittedMockExamResultIdState);
   const [isClicked, setIsClicked] = useState<'시험결과' | '틀린문제'>('시험결과');
   const [mockExamId, setMockExamId] = useRecoilState(mockExamIdState);
   const { examResults } = useGetTestResults(mockExamId);
+  const [userExamAttempt, setUserExamAttempt] = useState<number>(1);
+  const [isInitialLoad, setIsInitialLoad] = useState<boolean>(true);
   let totalTakenTime = 0;
+
+  useEffect(() => {
+    if (examResults && examResults.length > 0 && isInitialLoad) {
+      setUserExamAttempt(examResults.length);
+      setIsInitialLoad(false); // 초기화 완료 후 상태 업데이트
+    }
+  }, [examResults, isInitialLoad]);
+
   const sumTotalTakenTime = () => {
     if (examResults) {
-      examResults[examResults.length - 1]?.subjectResults.map((subjectResult)=>{
+      examResults[examResults.length - 1]?.subjectResults.map((subjectResult) => {
         totalTakenTime += subjectResult.totalTakenTime;
       });
       return totalTakenTime;
@@ -32,35 +41,84 @@ const Result = () => {
     }
   };
 
+  /**
+   * ExamResults 리스트의 값이 1개 이상일 경우 필터 적용 1개일 경우는 적용 X
+   * @param examResults 시험 결과
+   */
+  const displayComponentBasedOnExamResults = (examResults: MockExamResultType[] | null) => {
+    if (examResults && examResults.length === 1) {
+      return (
+        <>
+          {isClicked === '시험결과' ? (
+            <div className={'flex flex-col gap-y-5'}>
+              <MockExamResultReport
+                timeLimit={examResults ? examResults[examResults.length - 1]?.mockExam.timeLimit : 0}
+                totalTakenTime={sumTotalTakenTime}
+                totalScore={100}
+                score={examResults ? examResults[examResults.length - 1]?.totalScore : 0}
+                subjectResults={examResults ? examResults[examResults.length - 1]?.subjectResults : []}
+              />
+              <TakenTimeGraphReport
+                totalTakenTime={sumTotalTakenTime}
+                subjectResults={examResults ? examResults[examResults.length - 1]?.subjectResults : []}
+                timeLimit={examResults ? examResults[examResults.length - 1]?.mockExam.timeLimit : 0}
+              />
+              <AccuracyChart subjectResults={examResults ? examResults[examResults.length - 1]?.subjectResults : []} />
+            </div>
+          ) : (
+            <div>
+              <div>
+                <IncorrectQuestions submittedMockExamResultId={submittedMockExamResultId} />
+              </div>
+            </div>
+          )}
+        </>
+      );
+    } else if (examResults && examResults.length >= 2) {
+      return (
+        <>
+          <UserExamAttemptsFilterContent
+            userExamAttempts={examResults}
+            userExamAttempt={userExamAttempt - 1}
+            setUserExamAttempt={setUserExamAttempt}
+          />
+          {isClicked === '시험결과' ? (
+            <div className={'flex flex-col gap-y-5'}>
+              <MockExamResultReport
+                timeLimit={examResults ? examResults[userExamAttempt - 1]?.mockExam.timeLimit : 0}
+                totalTakenTime={sumTotalTakenTime}
+                totalScore={100}
+                score={examResults ? examResults[userExamAttempt - 1]?.totalScore : 0}
+                subjectResults={examResults ? examResults[userExamAttempt - 1]?.subjectResults : []}
+              />
+              <TakenTimeGraphReport
+                totalTakenTime={sumTotalTakenTime}
+                subjectResults={examResults ? examResults[userExamAttempt - 1]?.subjectResults : []}
+                timeLimit={examResults ? examResults[userExamAttempt - 1]?.mockExam.timeLimit : 0}
+              />
+              <AccuracyChart subjectResults={examResults ? examResults[userExamAttempt - 1]?.subjectResults : []} />
+            </div>
+          ) : (
+            <div>
+              <div>
+                <IncorrectQuestions
+                  submittedMockExamResultId={examResults ? examResults[userExamAttempt - 1]?.mockExamResultId : 0}
+                />
+              </div>
+            </div>
+          )}
+        </>
+      );
+    } else {
+      return null; // examResults가 비어 있는 경우 null을 반환
+    }
+  };
+
   return (
     <>
       <Header headerType={'dynamic'} title={'성적리포트'}></Header>
       <MockExamReportHeader isClicked={isClicked} setIsClicked={setIsClicked} />
-      <div className={'bg-gray0 min-h-screen p-5'}>
-        {isClicked === '시험결과' ? (
-          <div className={'flex flex-col gap-y-5'}>
-            <MockExamResultReport
-              timeLimit={examResults ? examResults[examResults.length - 1]?.mockExam.timeLimit : 0}
-              totalTakenTime={sumTotalTakenTime}
-              totalScore={100}
-              score={examResults ? examResults[examResults.length - 1]?.totalScore : 0}
-              subjectResults={examResults ? examResults[examResults.length - 1]?.subjectResults : []}
-            />
-            <TakenTimeGraphReport
-              totalTakenTime={sumTotalTakenTime}
-              subjectResults={examResults ? examResults[examResults.length - 1]?.subjectResults : []}
-              timeLimit={examResults ? examResults[examResults.length - 1]?.mockExam.timeLimit : 0}
-            />
-            <AccuracyChart subjectResults={examResults ? examResults[examResults.length - 1]?.subjectResults : []} />
-          </div>
-        ) : (
-          <div>
-            <div>
-              <IncorrectQuestions submittedMockExamResultId={submittedMockExamResultId} />
-            </div>
-          </div>
-        )}
-      </div>
+      <div className={'bg-gray0 min-h-screen p-5'}>{displayComponentBasedOnExamResults(examResults)}</div>
       <NavBar />
     </>
   );

--- a/src/app/(main)/exam/result/page.tsx
+++ b/src/app/(main)/exam/result/page.tsx
@@ -1,5 +1,61 @@
+'use client';
+import { useState } from 'react';
+import { useRecoilState } from 'recoil';
+
+import Header from '@/components/common/Header';
+import NavBar from '@/components/common/NavBar';
+import CorrectRateGraph from '@/components/exam/CorrectRateGraph';
+import MockExamReportHeader from '@/components/exam/MockExamReportHeader';
+import MockExamResultReport from '@/components/exam/MockExamResultReport';
+import StayTimeGraph from '@/components/exam/StayTimeGraph';
+import useGetTestResults from '@/lib/hooks/useGetTestResults';
+import { mockExamIdState, submittedMockExamResultIdState } from '@/recoil/exam/atom';
+
 const Result = () => {
-  return <div>결과 페이지임 ~ ㅋㅋ</div>;
+  const [submittedMockExamResultId, setSubmittedMockExamResultId] = useRecoilState(submittedMockExamResultIdState);
+  const [isClicked, setIsClicked] = useState<'시험결과' | '틀린문제'>('시험결과');
+  const [mockExamId, setMockExamId] = useRecoilState(mockExamIdState);
+  const { examResults } = useGetTestResults(mockExamId);
+  let totalTakenTime = 0;
+  const sumTotalTakenTime = () => {
+    if (examResults) {
+      examResults[examResults.length - 1]?.subjectResults.map((subjectResult)=>{
+        totalTakenTime += subjectResult.totalTakenTime;
+      });
+      return totalTakenTime;
+    } else {
+      return 0;
+    }
+  };
+
+  return (
+    <>
+      <Header headerType={'dynamic'} title={'성적리포트'}></Header>
+      <MockExamReportHeader isClicked={isClicked} setIsClicked={setIsClicked} />
+      <div className={'bg-gray0 min-h-screen p-5'}>
+        {isClicked === '시험결과' ? (
+          <div className={'flex flex-col gap-y-5'}>
+            <MockExamResultReport
+              timeLimit={examResults ? examResults[examResults.length - 1]?.mockExam.timeLimit : 0}
+              totalTakenTime={sumTotalTakenTime}
+              totalScore={100}
+              score={examResults ? examResults[examResults.length - 1]?.totalScore : 0}
+              subjectResults={examResults ? examResults[examResults.length - 1]?.subjectResults : []}
+            />
+            {/*<StayTimeGraph ></StayTimeGraph>*/}
+            {/*<CorrectRateGraph></CorrectRateGraph>*/}
+          </div>
+        ) : (
+          <div>
+            <div>
+              틀린문제
+            </div>
+          </div>
+        )}
+      </div>
+      <NavBar />
+    </>
+  );
 };
 
 export default Result;

--- a/src/app/(main)/exam/result/page.tsx
+++ b/src/app/(main)/exam/result/page.tsx
@@ -7,9 +7,9 @@ import NavBar from '@/components/common/NavBar';
 import CorrectRateGraph from '@/components/exam/CorrectRateGraph';
 import MockExamReportHeader from '@/components/exam/MockExamReportHeader';
 import MockExamResultReport from '@/components/exam/MockExamResultReport';
-import StayTimeGraph from '@/components/exam/StayTimeGraph';
 import useGetTestResults from '@/lib/hooks/useGetTestResults';
 import { mockExamIdState, submittedMockExamResultIdState } from '@/recoil/exam/atom';
+import TakenTimeGraphReport from '@/components/exam/TakenTimeGraphReport';
 
 const Result = () => {
   const [submittedMockExamResultId, setSubmittedMockExamResultId] = useRecoilState(submittedMockExamResultIdState);
@@ -42,7 +42,11 @@ const Result = () => {
               score={examResults ? examResults[examResults.length - 1]?.totalScore : 0}
               subjectResults={examResults ? examResults[examResults.length - 1]?.subjectResults : []}
             />
-            {/*<StayTimeGraph ></StayTimeGraph>*/}
+            <TakenTimeGraphReport
+              totalTakenTime={sumTotalTakenTime}
+              subjectResults={examResults ? examResults[examResults.length - 1]?.subjectResults : []}
+              timeLimit={examResults ? examResults[examResults.length - 1]?.mockExam.timeLimit : 0}
+            />
             {/*<CorrectRateGraph></CorrectRateGraph>*/}
           </div>
         ) : (

--- a/src/app/(main)/exam/result/page.tsx
+++ b/src/app/(main)/exam/result/page.tsx
@@ -1,16 +1,19 @@
 'use client';
+import { ResponsiveRadar } from '@nivo/radar';
 import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 
 import Header from '@/components/common/Header';
 import NavBar from '@/components/common/NavBar';
 import CorrectRateGraph from '@/components/exam/CorrectRateGraph';
+import IncorrectQuestions from '@/components/exam/IncorrectQuestions';
 import MockExamReportHeader from '@/components/exam/MockExamReportHeader';
 import MockExamResultReport from '@/components/exam/MockExamResultReport';
 import TakenTimeGraphReport from '@/components/exam/TakenTimeGraphReport';
 import useGetTestResults from '@/lib/hooks/useGetTestResults';
 import { mockExamIdState, submittedMockExamResultIdState } from '@/recoil/exam/atom';
-import IncorrectQuestions from '@/components/exam/IncorrectQuestions';
+import { subjectData } from '@/utils/common/accuracyChart';
+import AccuracyChart from '@/lib/hooks/AccuracyChart';
 
 const Result = () => {
   const [submittedMockExamResultId, setSubmittedMockExamResultId] = useRecoilState(submittedMockExamResultIdState);
@@ -48,12 +51,12 @@ const Result = () => {
               subjectResults={examResults ? examResults[examResults.length - 1]?.subjectResults : []}
               timeLimit={examResults ? examResults[examResults.length - 1]?.mockExam.timeLimit : 0}
             />
-            {/*<CorrectRateGraph></CorrectRateGraph>*/}
+            <AccuracyChart subjectResults={examResults ? examResults[examResults.length - 1]?.subjectResults : []} />
           </div>
         ) : (
           <div>
             <div>
-              <IncorrectQuestions />
+              <IncorrectQuestions submittedMockExamResultId={submittedMockExamResultId} />
             </div>
           </div>
         )}

--- a/src/components/common/Banner.tsx
+++ b/src/components/common/Banner.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link';
+import type { SVGProps } from 'react';
+import * as React from 'react';
 
 interface Props {
   title: string;
@@ -10,13 +12,22 @@ export default function Banner(props: Props) {
   const { title, buttonText, href } = props;
 
   return (
-    <div className="mx-auto mt-4 p-3 rounded-3xl bg-second">
-      <div className="px-2">
-        <div className="text-white font-bold text-left text-h4 my-1">{title}</div>
+    <div className="py-[16px] px-[16px] rounded-[32px] bg-second">
+      <div className="flex flex-col gap-y-3">
+        <div className="text-white font-semibold text-left text-h3 my-1">{title}</div>
         <Link href={href}>
-          <div className="inline-block rounded-3xl bg-white text-blue text-h6 my-1 px-3 py-1">{buttonText} ➚</div>
+          <div className="flex px-[12px] py-1 rounded-full items-center w-fit bg-white text-blue text-h6">
+            {buttonText}
+            <MoveIcon />
+          </div>
         </Link>
       </div>
     </div>
   );
 }
+
+const MoveIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={17} height={17} fill="none" {...props}>
+    <path stroke="#6283FD" strokeLinecap="round" strokeLinejoin="round" d="m5.75 11.5 6-6M5.75 5.5h6v6" />
+  </svg>
+);

--- a/src/components/community/CommentaryBoardList.tsx
+++ b/src/components/community/CommentaryBoardList.tsx
@@ -28,7 +28,7 @@ const CommentaryBoardList = (props: Props) => {
   const [selectedCommentaryRoundFilterContent, setSelectedCommentaryRoundFilterContent] = useState<number | string>(
     '전체',
   );
-  const { examYears } = useGetMockExamYears(); //해설 년도 필터값
+  const { examYears } = useGetMockExamYears('CommentaryBoardList'); //해설 년도 필터값
   const { mockExams } = useGetMockExams(1, selectedCommentaryYearFilterContent); //해설 회차 필터값
   const [ref, inView] = useInView();
   const router = useRouter();

--- a/src/components/community/EditPost.tsx
+++ b/src/components/community/EditPost.tsx
@@ -17,7 +17,7 @@ import { EditPostDataType, TipPostTagType } from '@/types/community/type';
 const EditPost = () => {
   const { postDetailData } = useGetPost();
   const { questions } = useMockExamQuestions();
-  const { examYears } = useGetMockExamYears();
+  const { examYears } = useGetMockExamYears('EditPost');
   const [editPostData, setEditPostData] = useRecoilState(editPostDataState);
   const [onlineCourseInputs, setOnlineCourseInputs] = useState<string[]>([]);
   const [workbookInputs, setWorkbookInputs] = useState<string[]>([]);

--- a/src/components/community/WriteExplanationPost.tsx
+++ b/src/components/community/WriteExplanationPost.tsx
@@ -11,7 +11,7 @@ import useMockExamQuestions from '@/lib/hooks/useMockExamQuestions';
 import { createPostDataState, imagePreviewsState, imageUrlListState } from '@/recoil/community/atom';
 
 const WriteExplanationPost = () => {
-  const { examYears } = useGetMockExamYears();
+  const { examYears } = useGetMockExamYears('WriteExplanationPost');
   const { questions } = useMockExamQuestions();
   const [isYearsFilterOpen, setIsYearsFilterOpen] = useState(false);
   const [isRoundsFilterOpen, setIsRoundsFilterOpen] = useState(false);

--- a/src/components/exam/IncorrectQuestionCard.tsx
+++ b/src/components/exam/IncorrectQuestionCard.tsx
@@ -4,13 +4,13 @@ import { useRecoilState } from 'recoil';
 
 import QuestionContent from '@/components/exam/QuestionContent';
 import { userAnswerRequests } from '@/recoil/exam/atom';
-import { Question, ReviewIncorrectMockExam, UserAnswerRequests } from '@/types/global';
+import { Question, QuestionOptions, ReviewIncorrectMockExam, UserAnswerRequests } from '@/types/global';
 
 interface Props {
   selectOptionSeq: number;
   mockExam: ReviewIncorrectMockExam;
   correctOption: number;
-  questionOptions: Question[];
+  questionOptions: QuestionOptions[];
   questionText: string;
   questionSeq: number;
 }

--- a/src/components/exam/IncorrectQuestions.tsx
+++ b/src/components/exam/IncorrectQuestions.tsx
@@ -4,10 +4,13 @@ import { useInView } from 'react-intersection-observer';
 import IncorrectQuestionCard from '@/components/exam/IncorrectQuestionCard';
 import useGetIncorrectQuestionsResult from '@/lib/hooks/useGetIncorrectQuestionsResult';
 import { MockExamIncorrectQuestionsResult, MockExamIncorrectQuestionsResultResponseType } from '@/types/exam/type';
-
-const IncorrectQuestions = () => {
+interface Props {
+  submittedMockExamResultId: number;
+}
+const IncorrectQuestions = (props: Props) => {
+  const { submittedMockExamResultId } = props;
   const [ref, inView] = useInView();
-  const { incorrectQuestionsResult, setSize } = useGetIncorrectQuestionsResult(55);
+  const { incorrectQuestionsResult, setSize } = useGetIncorrectQuestionsResult(submittedMockExamResultId);
 
   const getMoreItem = useCallback(async () => {
     if (incorrectQuestionsResult) {

--- a/src/components/exam/IncorrectQuestions.tsx
+++ b/src/components/exam/IncorrectQuestions.tsx
@@ -1,0 +1,51 @@
+import { useCallback, useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
+
+import IncorrectQuestionCard from '@/components/exam/IncorrectQuestionCard';
+import useGetIncorrectQuestionsResult from '@/lib/hooks/useGetIncorrectQuestionsResult';
+import { MockExamIncorrectQuestionsResult, MockExamIncorrectQuestionsResultResponseType } from '@/types/exam/type';
+
+const IncorrectQuestions = () => {
+  const [ref, inView] = useInView();
+  const { incorrectQuestionsResult, setSize } = useGetIncorrectQuestionsResult(55);
+
+  const getMoreItem = useCallback(async () => {
+    if (incorrectQuestionsResult) {
+      setSize((prev: number) => prev + 1);
+    }
+    return;
+  }, []);
+
+  useEffect(() => {
+    if (inView) {
+      getMoreItem();
+    }
+  }, [inView]);
+
+  return (
+    <>
+      <div className={'flex flex-col bg-gray0 gap-y-5'}>
+        {incorrectQuestionsResult
+          ? incorrectQuestionsResult.map((pastWrongQuestion: MockExamIncorrectQuestionsResultResponseType) => {
+              return pastWrongQuestion?.result.content.map(
+                (wrongQuestion: MockExamIncorrectQuestionsResult, index: number) => {
+                  return (
+                    <div key={index} ref={ref}>
+                      <IncorrectQuestionCard
+                        selectOptionSeq={wrongQuestion.selectOptionSeq}
+                        mockExam={wrongQuestion.question.mockExam}
+                        correctOption={wrongQuestion.question.correctOption}
+                        questionOptions={wrongQuestion.question.questionOptions}
+                        questionText={wrongQuestion.question.questionText}
+                        questionSeq={wrongQuestion.question.questionSeq}></IncorrectQuestionCard>
+                    </div>
+                  );
+                },
+              );
+            })
+          : null}
+      </div>
+    </>
+  );
+};
+export default IncorrectQuestions;

--- a/src/components/exam/MockExamReportHeader.tsx
+++ b/src/components/exam/MockExamReportHeader.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+interface Props {
+  isClicked: '시험결과' | '틀린문제';
+  setIsClicked: React.Dispatch<React.SetStateAction<'시험결과' | '틀린문제'>>;
+}
+const MockExamReportHeader = (props: Props) => {
+  const { isClicked, setIsClicked } = props;
+  return (
+    <div className={'mt-3 flex w-full bg-white px-5'}>
+      <div
+        onClick={() => {
+          setIsClicked('시험결과');
+        }}
+        className={
+          isClicked === '시험결과'
+            ? 'flex justify-center w-full py-2 text-black text-h6 border-b-[3px] border-b-primary'
+            : 'flex justify-center w-full py-2 text-gray3 text-h6 font-semibold'
+        }>
+        시험결과
+      </div>
+      <div
+        onClick={() => {
+          setIsClicked('틀린문제');
+        }}
+        className={
+          isClicked === '틀린문제'
+            ? 'flex justify-center w-full py-2 text-black text-h6 border-b-[3px] border-b-primary'
+            : 'flex justify-center w-full py-2 text-gray3 text-h6 font-semibold'
+        }>
+        틀린문제
+      </div>
+    </div>
+  );
+};
+export default MockExamReportHeader;

--- a/src/components/exam/MockExamResultReport.tsx
+++ b/src/components/exam/MockExamResultReport.tsx
@@ -1,0 +1,76 @@
+import SubjectGradeCard from '@/components/exam/SubjectGradeCard';
+import { SubjectResultsType } from '@/types/exam/type';
+
+type usageType = 'timeLimit' | 'takenTime';
+interface Props {
+  subjectResults: SubjectResultsType[];
+  score: number;
+  totalScore: number;
+  totalTakenTime: () => number;
+  timeLimit: number;
+}
+const MockExamResultReport = (props: Props) => {
+  const { subjectResults, score, totalScore, totalTakenTime, timeLimit} = props;
+  const formatTime = (time: number, usage: usageType) => {
+    const totalSeconds = Math.floor(time / 1000);
+    const totalMinutes = Math.floor(totalSeconds / 60);
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    const seconds = totalSeconds % 60;
+
+    if (usage === 'timeLimit') {
+      if (hours > 0) {
+        // 1시간 이상일 때 "시간:분" 형식으로 출력
+        return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}(시간)`;
+      } else {
+        // 1시간 미만일 때 "분:초" 형식으로 출력
+        return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}(분)`;
+      }
+    } else {
+      if (hours > 0) {
+        // 1시간 이상일 때 "시간:분" 형식으로 출력
+        return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+      } else {
+        // 1시간 미만일 때 "분:초" 형식으로 출력
+        return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+      }
+    }
+  };
+
+  return (
+    <>
+      <div className={'flex flex-col gap-y-2'}>
+        <div className={'text-h3 font-semibold'}>과목별 맞춘 문제 수</div>
+        <div className={'flex'}>
+          {subjectResults?.map((subjectResult, index) => {
+            return (
+              <div className={'w-full'} key={index}>
+                <SubjectGradeCard
+                  name={subjectResult.subject.subjectName}
+                  correctAnswer={subjectResult.numberOfCorrect}
+                  totalCorrect={20}></SubjectGradeCard>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className={'flex gap-x-2'}>
+        <div className={'px-4 py-3 rounded-[16px] bg-white w-full'}>
+          <div className={'text-h6 font-semibold'}>최근 점수</div>
+          <div className={'text-h1 font-semibold text-black'}>
+            {score}점<span className={'text-gray3 text-h6 font-normal'}>/{totalScore}점</span>
+          </div>
+        </div>
+        <div className={'px-4 py-3 rounded-[16px] bg-white w-full'}>
+          <div className={'text-h6 font-semibold'}>걸린 시간</div>
+          <div className={'text-h1 font-semibold text-black'}>
+            {formatTime(totalTakenTime(), 'takenTime')}
+            <span className={'text-gray3 text-h6 font-normal'}>/{formatTime(timeLimit, 'timeLimit')}</span>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+export default MockExamResultReport;

--- a/src/components/exam/MockExamYearsFilter.tsx
+++ b/src/components/exam/MockExamYearsFilter.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface Props {
+  yearList: number[];
+  setIsClickedYearSelector: React.Dispatch<React.SetStateAction<boolean>>;
+  setSelectedYear: React.Dispatch<React.SetStateAction<number>>;
+}
+const MockExamYearsFilter = (props: Props) => {
+  const { yearList, setIsClickedYearSelector, setSelectedYear } = props;
+  return (
+    <div className={'absolute top-[39%] w-[90%] border-[1px] border-gray2 bg-white rounded-[16px] py-2'}>
+      {!yearList || yearList.length === 0 ? (
+        <div>error</div>
+      ) : (
+        yearList.map((year: number, index: number) => {
+          return (
+            <div
+              key={index}
+              className="text-h4 text-gray3 py-3 px-4 hover:text-black transition"
+              onClick={() => {
+                setIsClickedYearSelector(false);
+                setSelectedYear(year);
+              }}>
+              {year}년도 기출 모의고사
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+};
+export default MockExamYearsFilter;

--- a/src/components/exam/Question.tsx
+++ b/src/components/exam/Question.tsx
@@ -6,7 +6,9 @@ import { useRecoilState } from 'recoil';
 import QuestionContent from '@/components/exam/QuestionContent';
 import useMockExamQuestions from '@/lib/hooks/useMockExamQuestions';
 import {
-  questionIndex, stopwatchIsPaused,
+  mockExamIdState,
+  questionIndex,
+  stopwatchIsPaused,
   stopwatchIsRunning,
   stopwatchTime,
   userAnswerRequests,
@@ -17,7 +19,8 @@ import { Question, QuestionsResponse, UserAnswerRequests } from '@/types/global'
 import { AllQuestionModal } from './AllQuestionModal';
 
 const Question = () => {
-  const { questions, isLoading, isError } = useMockExamQuestions();
+  const [selectedMockExamId, setSelectedMockExamId] = useRecoilState(mockExamIdState);
+  const { questions, isLoading, isError } = useMockExamQuestions(selectedMockExamId);
   const [questionIdx, setQuestionIdx] = useRecoilState<number>(questionIndex);
   const [allQuestionModalIsOpen, setAllQuestionModalIsOpen] = useState(false);
   const [userAnswer, setUserAnswer] = useRecoilState<UserAnswerRequests>(userAnswerRequests);

--- a/src/components/exam/Question.tsx
+++ b/src/components/exam/Question.tsx
@@ -110,8 +110,8 @@ const Question = () => {
 
     if (isRunning && !isPaused) {
       interval = setInterval(() => {
-        setTime((prevTime) => prevTime + 1);
-      }, 1);
+        setTime((prevTime) => prevTime + 1000);
+      }, 1000);
     } else {
       clearInterval(interval);
     }

--- a/src/components/exam/Question.tsx
+++ b/src/components/exam/Question.tsx
@@ -87,7 +87,7 @@ const Question = () => {
   };
 
   /**
-   * 처음 랜더링 될 때, userAnswerLis t을 기본값으로 채워주는 기능
+   * 처음 랜더링 될 때, userAnswerList 을 기본값으로 채워주는 기능
    */
   useEffect(() => {
     if (questions?.length > 0 && userAnswerList.length === 0) {

--- a/src/components/exam/SessionModal.tsx
+++ b/src/components/exam/SessionModal.tsx
@@ -29,8 +29,8 @@ const SessionModal: React.FC<SessionModalProps> = ({ round, mockExamId, closeMod
     <div>
       <div className="fixed z-20 inset-0 flex items-center justify-center bg-black bg-opacity-30">
         <div className="w-[80%]">
-          <button onClick={closeModal} className="w-full flex justify-end text-white text-h6 px-2 my-2">
-            닫기 X
+          <button onClick={closeModal} className="w-full flex justify-end items-center text-white text-h6 px-2 my-2">
+            닫기 <CancleIcon />
           </button>
           <div className="relative bg-white rounded-[32px]">
             <div className="flex flex-col gap-y-4 p-5">
@@ -61,8 +61,7 @@ const SessionModal: React.FC<SessionModalProps> = ({ round, mockExamId, closeMod
                 </div>
               </div>
               <div>
-                {examResults && examResults[examResults?.length - 1]?.subjectResults
-                  ? (
+                {examResults && examResults[examResults?.length - 1]?.subjectResults ? (
                   <div className={'flex flex-col gap-y-2'}>
                     <div className="text-h6 font-semibold">과목별 맞춘 문제 수</div>
                     <div className={'flex'}>
@@ -111,5 +110,28 @@ const AfterIcon = (props: SVGProps<SVGSVGElement>) => (
 const MoveIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg xmlns="http://www.w3.org/2000/svg" width={16} height={17} fill="none" {...props}>
     <path stroke="#0D0E10" strokeLinecap="round" strokeLinejoin="round" d="m5 11.5 6-6M5 5.5h6v6" />
+  </svg>
+);
+
+const CancleIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} fill="none" {...props}>
+    <mask
+      id="a"
+      width={24}
+      height={24}
+      x={0}
+      y={0}
+      maskUnits="userSpaceOnUse"
+      style={{
+        maskType: 'alpha',
+      }}>
+      <path fill="#D9D9D9" d="M0 0h24v24H0z" />
+    </mask>
+    <g mask="url(#a)">
+      <path
+        fill="#fff"
+        d="m12 12.708-5.246 5.246a.5.5 0 0 1-.344.15.47.47 0 0 1-.364-.15.5.5 0 0 1-.16-.354.5.5 0 0 1 .16-.354L11.292 12 6.046 6.754a.5.5 0 0 1-.15-.344.47.47 0 0 1 .15-.364.5.5 0 0 1 .354-.16.5.5 0 0 1 .354.16L12 11.292l5.246-5.246a.5.5 0 0 1 .344-.15.47.47 0 0 1 .364.15.5.5 0 0 1 .16.354.5.5 0 0 1-.16.354L12.708 12l5.246 5.246a.5.5 0 0 1 .15.344.47.47 0 0 1-.15.364.5.5 0 0 1-.354.16.5.5 0 0 1-.354-.16z"
+      />
+    </g>
   </svg>
 );

--- a/src/components/exam/SessionModal.tsx
+++ b/src/components/exam/SessionModal.tsx
@@ -9,15 +9,15 @@ import SubjectGradeCard from './SubjectGradeCard';
 
 interface SessionModalProps {
   round: number;
-  MockExamId: number;
+  mockExamId: number;
   closeModal: () => void;
   openTimerModal: () => void;
   total: number;
 }
 
-const SessionModal: React.FC<SessionModalProps> = ({ round, MockExamId, closeModal, openTimerModal, total }) => {
+const SessionModal: React.FC<SessionModalProps> = ({ round, mockExamId, closeModal, openTimerModal, total }) => {
   const [changedRound, setChangedRound] = useState<number>(0);
-  const { examResults } = useGetExamResults(MockExamId);
+  const { examResults } = useGetExamResults(mockExamId);
 
   useEffect(() => {
     if (round) {

--- a/src/components/exam/SessionModal.tsx
+++ b/src/components/exam/SessionModal.tsx
@@ -3,7 +3,7 @@ import { SVGProps, useEffect, useState } from 'react';
 import React from 'react';
 
 import useGetExamResultRecent from '@/lib/hooks/useGetExamResultRecent';
-import useGetExamResults from '@/lib/hooks/useGetExamResults';
+import useGetTestResults from '@/lib/hooks/useGetTestResults';
 
 import SubjectGradeCard from './SubjectGradeCard';
 
@@ -17,7 +17,7 @@ interface SessionModalProps {
 
 const SessionModal: React.FC<SessionModalProps> = ({ round, mockExamId, closeModal, openTimerModal, total }) => {
   const [changedRound, setChangedRound] = useState<number>(0);
-  const { examResults } = useGetExamResults(mockExamId);
+  const { examResults } = useGetTestResults(mockExamId);
 
   useEffect(() => {
     if (round) {

--- a/src/components/exam/SessionModal.tsx
+++ b/src/components/exam/SessionModal.tsx
@@ -1,63 +1,88 @@
 import Link from 'next/link';
-import React, { useState } from 'react';
-import { useRecoilState } from 'recoil';
+import { SVGProps, useEffect, useState } from 'react';
+import React from 'react';
 
-import { Session } from '@/types/global';
-import { selectedSessionState } from '@/utils/recoilState';
+import useGetExamResultRecent from '@/lib/hooks/useGetExamResultRecent';
+import useGetExamResults from '@/lib/hooks/useGetExamResults';
 
 import SubjectGradeCard from './SubjectGradeCard';
 
 interface SessionModalProps {
+  round: number;
+  MockExamId: number;
   closeModal: () => void;
   openTimerModal: () => void;
-  round: number;
-  main: number;
   total: number;
 }
 
-const SessionModal: React.FC<SessionModalProps> = ({ closeModal, openTimerModal, round, main, total }) => {
-  const [selectedSession, setSelectedSession] = useRecoilState<Session | null>(selectedSessionState);
+const SessionModal: React.FC<SessionModalProps> = ({ round, MockExamId, closeModal, openTimerModal, total }) => {
+  const [changedRound, setChangedRound] = useState<number>(0);
+  const { examResults } = useGetExamResults(MockExamId);
+
+  useEffect(() => {
+    if (round) {
+      setChangedRound(round);
+    }
+  }, [round]);
 
   return (
     <div>
-      <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-30">
+      <div className="fixed z-20 inset-0 flex items-center justify-center bg-black bg-opacity-30">
         <div className="w-[80%]">
           <button onClick={closeModal} className="w-full flex justify-end text-white text-h6 px-2 my-2">
             닫기 X
           </button>
-          <div className="bg-white rounded-3xl">
-            <div className="w-[90%] mx-auto">
-              <h2 className="flex justify-between text-h4 font-bold p-4">
-                <button>{'<'}</button>
+          <div className="relative bg-white rounded-[32px]">
+            <div className="flex flex-col gap-y-4 p-5">
+              <div className=" flex justify-center text-h4 font-bold">
                 <div>{`${round}회차`}</div>
-                <button>{'>'}</button>
-              </h2>
-              <div className="border-t border-gray1"></div>
-              <div className="flex justify-between my-3">
-                <div>
-                  <div className="font-bold text-h6">최근 점수</div>
-                  <div className="flex items-end">
-                    <div className="font-bold text-h1">{`${main}점`}</div>
-                    <div className="text-gray3 text-h6 mb-1">/{`${total}점`}</div>
-                  </div>
-                </div>
-                <Link href={'/exam/report'} className="h-1/2 bg-gray0 rounded-3xl text-h6 font-bold p-2">
-                  성적 리포트 ➚
-                </Link>
               </div>
-              <div className="text-h6 font-bold mt-5">과목별 맞춘 문제 수</div>
-              <div className="flex my-2">
-                {/* {subjects?.map((subject, index) => (
-                  <SubjectGradeCard key={index} name={'하이'} correctAnswer={12} totalCorrect={50} />
-                ))} */}
-                <SubjectGradeCard name={'하이'} correctAnswer={12} totalCorrect={50} />
-                <SubjectGradeCard name={'하이'} correctAnswer={12} totalCorrect={50} />
-                <SubjectGradeCard name={'하이'} correctAnswer={12} totalCorrect={50} />
+              <div className="border-t border-gray1"></div>
+              <div className="flex justify-between">
+                {examResults && examResults[examResults?.length - 1]?.totalScore ? (
+                  <Link
+                    href={'/exam/report'}
+                    className="absolute right-5 px-3 py-2 flex gap-x-2 items-center bg-gray0 rounded-full text-h6">
+                    <span>성적 리포트</span> <MoveIcon />
+                  </Link>
+                ) : null}
+                <div>
+                  <div className="font-semibold text-h6">최근 점수</div>
+                  {examResults && examResults[examResults?.length - 1]?.totalScore ? (
+                    <div className={''}>
+                      <div className="flex items-end">
+                        <div className="font-bold text-h1">{examResults[examResults?.length - 1].totalScore}점</div>
+                        <div className="text-gray3 text-h6 mb-1">/{`${total}점`}</div>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="font-bold text-h1">미응시</div>
+                  )}
+                </div>
+              </div>
+              <div>
+                {examResults && examResults[examResults?.length - 1]?.subjectResults
+                  ? (
+                  <div className={'flex flex-col gap-y-2'}>
+                    <div className="text-h6 font-semibold">과목별 맞춘 문제 수</div>
+                    <div className={'flex'}>
+                      {examResults[examResults?.length - 1]?.subjectResults?.map((subjectResult, index) => {
+                        return (
+                          <div className={'w-full'} key={index}>
+                            <SubjectGradeCard
+                              name={subjectResult.subject.subjectName}
+                              correctAnswer={subjectResult.numberOfCorrect}
+                              totalCorrect={20}
+                            />
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ) : null}
               </div>
               <div className="flex justify-center">
-                <button
-                  onClick={() => openTimerModal()}
-                  className="w-full bg-black text-white rounded-3xl text-h5 p-4 my-4">
+                <button onClick={() => openTimerModal()} className="w-full bg-black text-white rounded-3xl text-h5 p-4">
                   시험 보기
                 </button>
               </div>
@@ -70,3 +95,21 @@ const SessionModal: React.FC<SessionModalProps> = ({ closeModal, openTimerModal,
 };
 
 export default SessionModal;
+
+const BeforeIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={28} height={28} fill="none" {...props}>
+    <path stroke="#0D0E10" strokeLinecap="round" strokeLinejoin="round" d="m18 22-8-8 8-8" />
+  </svg>
+);
+
+const AfterIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={28} height={28} fill="none" {...props}>
+    <path stroke="#0D0E10" strokeLinecap="round" strokeLinejoin="round" d="m10 6 8 8-8 8" />
+  </svg>
+);
+
+const MoveIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={16} height={17} fill="none" {...props}>
+    <path stroke="#0D0E10" strokeLinecap="round" strokeLinejoin="round" d="m5 11.5 6-6M5 5.5h6v6" />
+  </svg>
+);

--- a/src/components/exam/SubjectCard.tsx
+++ b/src/components/exam/SubjectCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 
 import useGetExamResultRecent from '@/lib/hooks/useGetExamResultRecent';
@@ -7,6 +7,7 @@ import { selectedSessionState, selectedSubjectState } from '@/utils/recoilState'
 
 import SessionModal from './SessionModal';
 import TimerModal from './TimerModal';
+import { timeLimitState } from '@/recoil/exam/atom';
 
 interface SubjectCard {
   timeLimit: number;
@@ -23,6 +24,14 @@ const SubjectCard: React.FC<SubjectCard> = ({ timeLimit, round, mockExamId, tota
   // 모달 관련 states
   const [sessionModalIsOpen, setSessionModalIsOpen] = useState(false);
   const [timerModalIsOpen, setTimerModalIsOpen] = useState(false);
+  const [time, setTime] = useRecoilState(timeLimitState);
+
+  //제한 시간 설정
+  useEffect(() => {
+    if (timeLimit != 0) {
+      setTime(timeLimit);
+    }
+  }, [timeLimit]);
 
   // 모달이 열릴때 세션 상태 설정
   const openSessionModal = () => {

--- a/src/components/exam/SubjectCard.tsx
+++ b/src/components/exam/SubjectCard.tsx
@@ -9,13 +9,14 @@ import SessionModal from './SessionModal';
 import TimerModal from './TimerModal';
 
 interface SubjectCard {
+  timeLimit: number;
   round: number;
-  MockExamId: number;
+  mockExamId: number;
   total: number;
 }
 
-const SubjectCard: React.FC<SubjectCard> = ({ round, MockExamId, total }) => {
-  const { examResultRecent } = useGetExamResultRecent(MockExamId);
+const SubjectCard: React.FC<SubjectCard> = ({ timeLimit, round, mockExamId, total }) => {
+  const { examResultRecent } = useGetExamResultRecent(mockExamId);
   const [selectedSubject, setSelectedSubject] = useRecoilState<SubjectInfo | null>(selectedSubjectState);
   const [selectedSession, setSelectedSession] = useRecoilState<Session | null>(selectedSessionState);
 
@@ -64,7 +65,7 @@ const SubjectCard: React.FC<SubjectCard> = ({ round, MockExamId, total }) => {
       </div>
       {sessionModalIsOpen && (
         <SessionModal
-          MockExamId={MockExamId}
+          mockExamId={mockExamId}
           closeModal={closeSessionModal}
           openTimerModal={openTimerModal}
           total={total}
@@ -72,7 +73,15 @@ const SubjectCard: React.FC<SubjectCard> = ({ round, MockExamId, total }) => {
         />
       )}
       {/* 타이머 모달에 대한 코드 */}
-      {timerModalIsOpen && <TimerModal closeTimerModal={closeTimerModal} closeSessionModal={closeSessionModal} />}
+      {timerModalIsOpen && (
+        <TimerModal
+          mockExamId={mockExamId}
+          timeLimit={timeLimit}
+          round={round}
+          closeTimerModal={closeTimerModal}
+          closeSessionModal={closeSessionModal}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/exam/SubjectCard.tsx
+++ b/src/components/exam/SubjectCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 
+import useGetExamResultRecent from '@/lib/hooks/useGetExamResultRecent';
 import { Session, SubjectInfo } from '@/types/global';
 import { selectedSessionState, selectedSubjectState } from '@/utils/recoilState';
 
@@ -9,12 +10,12 @@ import TimerModal from './TimerModal';
 
 interface SubjectCard {
   round: number;
-  score: number;
+  MockExamId: number;
   total: number;
-  isTaken: boolean;
 }
 
-const SubjectCard: React.FC<SubjectCard> = ({ round, score, total, isTaken }) => {
+const SubjectCard: React.FC<SubjectCard> = ({ round, MockExamId, total }) => {
+  const { examResultRecent } = useGetExamResultRecent(MockExamId);
   const [selectedSubject, setSelectedSubject] = useRecoilState<SubjectInfo | null>(selectedSubjectState);
   const [selectedSession, setSelectedSession] = useRecoilState<Session | null>(selectedSessionState);
 
@@ -44,19 +45,20 @@ const SubjectCard: React.FC<SubjectCard> = ({ round, score, total, isTaken }) =>
 
   return (
     <div>
-      <div className="mx-2 p-3 border border-gray2 rounded-3xl">
-        <div className="text-black font-bold text-center">{`${round}회차`}</div>
-        <div className="border-t border-gray1 my-2"></div>
-        <div className="text-black text-center text-h7">최근 점수</div>
-        {isTaken ? (
-          <ul className="flex text-center justify-center">
-            <li className="font-bold text-h2">{`${score}점`}</li>
-            <div className="mt-1 text-gray3">{`/${total}점`}</div>
-          </ul>
-        ) : (
-          <p className="text-center text-h2 font-bold">미응시</p>
-        )}
-        <button onClick={() => openSessionModal()} className="w-full bg-gray1 rounded-3xl py-3 mt-4 text-h6 font-bold">
+      <div className="flex flex-col gap-y-4 p-3 border-[1px] border-gray2 rounded-[32px]">
+        <div className="font-semibold text-center pb-2 border-b border-gray1">{`${round}회차`}</div>
+        <div>
+          <div className="text-black text-center text-h7">최근 점수</div>
+          {examResultRecent ? (
+            <ul className="flex items-end justify-center">
+              <li className="font-bold text-h2">{`${examResultRecent.totalScore}점`}</li>
+              <div className="mb-[3px] text-gray3 text-h6">{`/${total}점`}</div>
+            </ul>
+          ) : (
+            <p className="text-center text-h2 font-semibold">미응시</p>
+          )}
+        </div>
+        <button onClick={() => openSessionModal()} className="w-full bg-gray0 rounded-3xl py-3 text-h6">
           시험 보기
         </button>
       </div>
@@ -65,7 +67,7 @@ const SubjectCard: React.FC<SubjectCard> = ({ round, score, total, isTaken }) =>
           closeModal={closeSessionModal}
           openTimerModal={openTimerModal}
           round={round}
-          main={score}
+          main={examResultRecent ? examResultRecent.totalScore : 0}
           total={total}
         />
       )}

--- a/src/components/exam/SubjectCard.tsx
+++ b/src/components/exam/SubjectCard.tsx
@@ -64,11 +64,11 @@ const SubjectCard: React.FC<SubjectCard> = ({ round, MockExamId, total }) => {
       </div>
       {sessionModalIsOpen && (
         <SessionModal
+          MockExamId={MockExamId}
           closeModal={closeSessionModal}
           openTimerModal={openTimerModal}
-          round={round}
-          main={examResultRecent ? examResultRecent.totalScore : 0}
           total={total}
+          round={round}
         />
       )}
       {/* 타이머 모달에 대한 코드 */}

--- a/src/components/exam/SubjectGradeCard.tsx
+++ b/src/components/exam/SubjectGradeCard.tsx
@@ -13,11 +13,11 @@ interface SubjectGradeCardProps {
 // 세부 과목별 성적을 나타내는 표 컴포넌트
 const SubjectGradeCard: React.FC<SubjectGradeCardProps> = ({ name, correctAnswer, totalCorrect }) => {
   return (
-    <div className={'w-full border border-gray2'}>
+    <div className={'w-full border border-gray2 bg-white'}>
       <div className="text-h6 text-center py-2 w-full">{name}</div>
       <div className="flex justify-center border-t border-gray2 py-2">
         <div className="flex items-end">
-          <div className="font-bold text-h3">{correctAnswer}개</div>
+          <div className="text-h3">{correctAnswer}개</div>
           <div className="text-gray3 text-h7">/{totalCorrect}개</div>
         </div>
       </div>

--- a/src/components/exam/SubjectGradeCard.tsx
+++ b/src/components/exam/SubjectGradeCard.tsx
@@ -13,8 +13,8 @@ interface SubjectGradeCardProps {
 // 세부 과목별 성적을 나타내는 표 컴포넌트
 const SubjectGradeCard: React.FC<SubjectGradeCardProps> = ({ name, correctAnswer, totalCorrect }) => {
   return (
-    <div className="w-full border border-gray2">
-      <div className="text-lg text-center text-h6 py-2">{name}</div>
+    <div className={'w-full border border-gray2'}>
+      <div className="text-h6 text-center py-2 w-full">{name}</div>
       <div className="flex justify-center border-t border-gray2 py-2">
         <div className="flex items-end">
           <div className="font-bold text-h3">{correctAnswer}개</div>

--- a/src/components/exam/SubjectList.tsx
+++ b/src/components/exam/SubjectList.tsx
@@ -1,9 +1,11 @@
 'use client';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import SubjectCard from '@/components/exam/SubjectCard';
 import useGetMockExams from '@/lib/hooks/useGetMockExams';
 import { ReviewIncorrectMockExam } from '@/types/global';
+import { useRecoilState } from 'recoil';
+import { timeLimitState } from '@/recoil/exam/atom';
 
 interface Props {
   selectedYear: number;

--- a/src/components/exam/SubjectList.tsx
+++ b/src/components/exam/SubjectList.tsx
@@ -18,7 +18,11 @@ const SubjectSessionCard = (props: Props) => {
       {mockExams?.map((mockExam: ReviewIncorrectMockExam, index: number) => {
         return (
           <div key={index}>
-            <SubjectCard total={300} round={mockExam.round} MockExamId={mockExam.MockExamId}></SubjectCard>
+            <SubjectCard
+              timeLimit={mockExam.timeLimit}
+              total={300}
+              round={mockExam.round}
+              mockExamId={mockExam.MockExamId}></SubjectCard>
           </div>
         );
       })}

--- a/src/components/exam/SubjectList.tsx
+++ b/src/components/exam/SubjectList.tsx
@@ -1,66 +1,28 @@
 'use client';
-import React, { useEffect } from 'react';
-import { useRecoilState } from 'recoil';
+import React from 'react';
 
-import { useGetExamYearData } from '@/lib/hooks/ExamInfoFetcher';
-import { roundsArrayState, YearState } from '@/utils/recoilState';
+import SubjectCard from '@/components/exam/SubjectCard';
+import useGetMockExams from '@/lib/hooks/useGetMockExams';
+import { ReviewIncorrectMockExam } from '@/types/global';
 
-import SubjectCard from './SubjectCard';
-
+interface Props {
+  selectedYear: number;
+}
 // 해당하는 연도의 회차별 데이터를 모두 출력
-const SubjectSessionCard: React.FC = ({}) => {
-  // 연도 데이터 불러오기
-  const [selectedYear] = useRecoilState<Number | undefined>(YearState);
-  const [roundArrays, setRoundArrays] = useRecoilState<number[] | undefined>(roundsArrayState);
+const SubjectSessionCard = (props: Props) => {
+  const { selectedYear } = props;
+  const { mockExams } = useGetMockExams(1, selectedYear);
 
-  // ExamID, round, istake 정보 실려옴
-  const { YearData } = useGetExamYearData(1, selectedYear);
-
-  // api 살아나면 살릴부분
-  // const rounds = YearData?.result;
-
-  const rounds = [
-    { round: 1, mockExamId: 23, isTake: true },
-    { round: 2, mockExamId: 56, isTake: false },
-    { round: 3, mockExamId: 89, isTake: true },
-  ];
-
-  console.log(rounds);
-
-  // api 살아나면 이부분 살려야함
-  // useEffect(() => {
-  //   if (rounds) {
-  //     const roundArray = rounds.map((item) => item.round);
-  //     setRoundArrays(roundArray);
-  //   }
-  // }, [rounds, setRoundArrays]);
-
-  if (!rounds) {
-    return (
-      <div>
-        {/* 이 부분 모듈로 뺍니다*/}
-        데이터 불러오는 중
-      </div>
-    );
-  }
-
-  // 여기서 selectedSession 에 대한 전역 상태가 결정됩니다.
   return (
-    <>
-      <div className="flex flex-wrap mt-5">
-        {rounds?.map((round, index) => {
-          if (round.round) {
-            return (
-              <div key={index} className="w-1/2 mb-4">
-                <SubjectCard round={round.round} score={round.mockExamId} total={50} isTaken={round.isTake} />
-              </div>
-            );
-          } else {
-            return null;
-          }
-        })}
-      </div>
-    </>
+    <div className={'mt-[16px] grid grid-cols-2 gap-x-4 gap-y-4'}>
+      {mockExams?.map((mockExam: ReviewIncorrectMockExam, index: number) => {
+        return (
+          <div key={index}>
+            <SubjectCard total={300} round={mockExam.round} MockExamId={mockExam.MockExamId}></SubjectCard>
+          </div>
+        );
+      })}
+    </div>
   );
 };
 

--- a/src/components/exam/SubmitConfirmationModal.tsx
+++ b/src/components/exam/SubmitConfirmationModal.tsx
@@ -2,14 +2,7 @@ import { useRouter } from 'next/navigation';
 import * as React from 'react';
 import { useRecoilState } from 'recoil';
 
-import { postSubjectResultRequestsList } from '@/lib/api/exam';
-import {
-  mockExamIdState,
-  stopwatchIsPaused,
-  stopwatchIsRunning,
-  subjectResultRequestsList,
-  timerIsPaused,
-} from '@/recoil/exam/atom';
+import { stopwatchIsPaused, stopwatchIsRunning, timerIsPaused } from '@/recoil/exam/atom';
 
 interface Props {
   isSubmitConfirmationModalOpen: boolean;
@@ -17,14 +10,12 @@ interface Props {
 }
 
 const SubmitConfirmationModal = (props: Props) => {
-  const [selectedMockExamId, setSelectedMockExamId] = useRecoilState(mockExamIdState);
   const { isSubmitConfirmationModalOpen, setIsSubmitConfirmationModalOpen } = props;
   // 모달창을 띄우면 타이머를 잠시 멈추게 하는 state
   const [isPausedTimer, setIsPausedTimer] = useRecoilState(timerIsPaused);
   // 문제당 머문시간을 잠시 멈추는
   const [isPausedStopWatch, setIsPausedStopWatch] = useRecoilState(stopwatchIsPaused);
   const [isRunning, setIsRunning] = useRecoilState<boolean>(stopwatchIsRunning);
-  const [subjectResultList, setSubjectResultList] = useRecoilState(subjectResultRequestsList)
   const router = useRouter();
 
   /**
@@ -33,6 +24,7 @@ const SubmitConfirmationModal = (props: Props) => {
   const onMove = async () => {
     router.push('/exam/result');
   };
+
   return (
     <>
       <div
@@ -58,9 +50,8 @@ const SubmitConfirmationModal = (props: Props) => {
             </button>
             <button
               onClick={async () => {
-                setIsRunning(false);
+                setIsRunning(false); //제출 트릭
                 setIsSubmitConfirmationModalOpen(!isSubmitConfirmationModalOpen);
-                await postSubjectResultRequestsList(subjectResultList, selectedMockExamId).then((r) => console.log(r));
                 await onMove();
               }}
               className={'bg-black rounded-full text-white py-[7px] px-3'}>

--- a/src/components/exam/SubmitConfirmationModal.tsx
+++ b/src/components/exam/SubmitConfirmationModal.tsx
@@ -2,7 +2,14 @@ import { useRouter } from 'next/navigation';
 import * as React from 'react';
 import { useRecoilState } from 'recoil';
 
-import { stopwatchIsPaused, stopwatchIsRunning, timerIsPaused } from '@/recoil/exam/atom';
+import { postSubjectResultRequestsList } from '@/lib/api/exam';
+import {
+  mockExamIdState,
+  stopwatchIsPaused,
+  stopwatchIsRunning,
+  subjectResultRequestsList,
+  timerIsPaused,
+} from '@/recoil/exam/atom';
 
 interface Props {
   isSubmitConfirmationModalOpen: boolean;
@@ -10,21 +17,22 @@ interface Props {
 }
 
 const SubmitConfirmationModal = (props: Props) => {
+  const [selectedMockExamId, setSelectedMockExamId] = useRecoilState(mockExamIdState);
   const { isSubmitConfirmationModalOpen, setIsSubmitConfirmationModalOpen } = props;
   // 모달창을 띄우면 타이머를 잠시 멈추게 하는 state
   const [isPausedTimer, setIsPausedTimer] = useRecoilState(timerIsPaused);
   // 문제당 머문시간을 잠시 멈추는
   const [isPausedStopWatch, setIsPausedStopWatch] = useRecoilState(stopwatchIsPaused);
   const [isRunning, setIsRunning] = useRecoilState<boolean>(stopwatchIsRunning);
+  const [subjectResultList, setSubjectResultList] = useRecoilState(subjectResultRequestsList)
   const router = useRouter();
 
   /**
    * 제출 버튼을 눌렀을 때, 결과 페이지로 이동하는 함수
    */
-  const onMove = () => {
+  const onMove = async () => {
     router.push('/exam/result');
   };
-
   return (
     <>
       <div
@@ -49,10 +57,11 @@ const SubmitConfirmationModal = (props: Props) => {
               닫기
             </button>
             <button
-              onClick={() => {
+              onClick={async () => {
                 setIsRunning(false);
                 setIsSubmitConfirmationModalOpen(!isSubmitConfirmationModalOpen);
-                onMove();
+                await postSubjectResultRequestsList(subjectResultList, selectedMockExamId).then((r) => console.log(r));
+                await onMove();
               }}
               className={'bg-black rounded-full text-white py-[7px] px-3'}>
               제출하기

--- a/src/components/exam/TakenTimeGraphReport.tsx
+++ b/src/components/exam/TakenTimeGraphReport.tsx
@@ -31,7 +31,7 @@ const TakenTimeGraphReport = (props: Props) => {
         <div className="flex items-end space-x-2">
           <div className="w-[85%]">
             <div className="flex h-32">
-              {subjectResults.map((subjectResult, index) => {
+              {subjectResults?.map((subjectResult, index) => {
                 return (
                   <div key={index} className="w-full flex justify-center space-x-2">
                     <StickGraph height={millisecondsToMinutes(subjectResult.totalTakenTime)} color="second" />
@@ -45,7 +45,7 @@ const TakenTimeGraphReport = (props: Props) => {
         </div>
         <div className="flex space-x-2">
           <div className="w-[85%] flex justify-between mt-[2%]">
-            {subjectResults.map((subjectResult, index) => (
+            {subjectResults?.map((subjectResult, index) => (
               <div key={index} className="w-full flex justify-center text-h7">
                 {subjectResult.subject.subjectName}
               </div>

--- a/src/components/exam/TakenTimeGraphReport.tsx
+++ b/src/components/exam/TakenTimeGraphReport.tsx
@@ -1,0 +1,60 @@
+import StickGraph from '@/components/exam/StickGraph';
+import { SubjectResultsType } from '@/types/exam/type';
+
+interface Props {
+  subjectResults: SubjectResultsType[];
+  timeLimit: number;
+  totalTakenTime: () => number;
+}
+const TakenTimeGraphReport = (props: Props) => {
+  const { subjectResults, timeLimit, totalTakenTime } = props;
+
+  const millisecondsToMinutes = (time: number) => {
+    // 1분은 60000 밀리세컨드입니다.
+    return Math.floor(time / 60000);
+  };
+
+  return (
+    <div className={'flex flex-col gap-y-3 p-4 rounded-[32px] bg-white'}>
+      <div className={'pl-1 text-h3 font-semibold'}>머문시간 그래프</div>
+      <div>
+        {/*걸린 시간*/}
+        <div className={'pl-2'}>
+          <div className={'text-h6'}>걸린시간</div>
+          <div className={'text-h3 font-semibold'}>{millisecondsToMinutes(totalTakenTime())}m</div>
+        </div>
+        {/*막대 그래프*/}
+        <div className="flex items-center space-x-2">
+          <div className="w-[85%] border-t border-gray1"></div>
+          <div className="w-[15%] text-gray3 text-h5">{millisecondsToMinutes(timeLimit)}분</div>
+        </div>
+        <div className="flex items-end space-x-2">
+          <div className="w-[85%]">
+            <div className="flex h-32">
+              {subjectResults.map((subjectResult, index) => {
+                return (
+                  <div key={index} className="w-full flex justify-center space-x-2">
+                    <StickGraph height={millisecondsToMinutes(subjectResult.totalTakenTime)} color="second" />
+                  </div>
+                );
+              })}
+            </div>
+            <div className="border-t border-gray1"></div>
+          </div>
+          <div className="w-[15%] text-gray3 text-h5">0분</div>
+        </div>
+        <div className="flex space-x-2">
+          <div className="w-[85%] flex justify-between mt-[2%]">
+            {subjectResults.map((subjectResult, index) => (
+              <div key={index} className="w-full flex justify-center text-h7">
+                {subjectResult.subject.subjectName}
+              </div>
+            ))}
+          </div>
+          <div className="w-[15%] text-white text-h5">0분</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+export default TakenTimeGraphReport;

--- a/src/components/exam/TestSubmitOrCancle.tsx
+++ b/src/components/exam/TestSubmitOrCancle.tsx
@@ -61,10 +61,6 @@ const TestSubmitOrCancle = (props: Props) => {
   const { calculateScore, prepareAndScoreSubjectResults } = useCalculateScore(selectedMockExamId);
   const [submittedMockExamResultId, setSubmittedMockExamResultId] = useRecoilState(submittedMockExamResultIdState);
 
-
-  useEffect(() => {
-    console.log('userAnswerList',userAnswerList)
-  }, [userAnswerList]);
   /**
    * 시험 시간 타이머 기능
    */
@@ -142,6 +138,7 @@ const TestSubmitOrCancle = (props: Props) => {
    */
   useEffect(() => {
     if (subjectResultList.length !== 0) {
+      console.log('선택된 모의고사 id', selectedMockExamId);
       postSubjectResultRequestsList(subjectResultList, selectedMockExamId).then((r) => {
         console.log(r);
         setSubmittedMockExamResultId(r.result.mockExamResultId);

--- a/src/components/exam/TestSubmitOrCancle.tsx
+++ b/src/components/exam/TestSubmitOrCancle.tsx
@@ -61,6 +61,10 @@ const TestSubmitOrCancle = (props: Props) => {
   const { calculateScore, prepareAndScoreSubjectResults } = useCalculateScore(selectedMockExamId);
   const [submittedMockExamResultId, setSubmittedMockExamResultId] = useRecoilState(submittedMockExamResultIdState);
 
+
+  useEffect(() => {
+    console.log('userAnswerList',userAnswerList)
+  }, [userAnswerList]);
   /**
    * 시험 시간 타이머 기능
    */

--- a/src/components/exam/TestSubmitOrCancle.tsx
+++ b/src/components/exam/TestSubmitOrCancle.tsx
@@ -7,6 +7,7 @@ import useCalculateScore from '@/hooks/useCalculateScore';
 import { postSubjectResultRequestsList } from '@/lib/api/exam';
 import useMockExamQuestions from '@/lib/hooks/useMockExamQuestions';
 import {
+  mockExamIdState,
   questionIndex,
   stopwatchIsPaused,
   stopwatchIsRunning,
@@ -35,7 +36,8 @@ const TestSubmitOrCancle = (props: Props) => {
     isAutoSubmitTimeUpModalOpen,
     setIsAutoSubmitTimeUpModalOpen,
   } = props;
-  const { calculateScore, prepareAndScoreSubjectResults } = useCalculateScore();
+  const [selectedMockExamId, setSelectedMockExamId] = useRecoilState(mockExamIdState);
+  const { calculateScore, prepareAndScoreSubjectResults } = useCalculateScore(selectedMockExamId);
   // 남은 시간(타이머) TODO: questions[0].mockExam.timeLimit으로 변경
   const [timeLeft, setTimeLeft] = useState(5400000); //5400000
   // 각 문제당 걸린 시간
@@ -117,17 +119,6 @@ const TestSubmitOrCancle = (props: Props) => {
       prepareAndScoreSubjectResults();
     }
   }, [userAnswerList[0]?.isCorrect]);
-
-  /**
-   * prepareAndScoreSubjectResults 가 다 완료되고, subjectResultList 에 값이 다 저장될 때,
-   * 서버에 post 요청을 보내는 코드
-   */
-  useEffect(() => {
-    if (subjectResultList.length !== 0) {
-      postSubjectResultRequestsList(subjectResultList).then((r) => console.log(r));
-      setSubjectResultList([]); //다시 제출 방지
-    }
-  }, [subjectResultList]);
 
   /**
    * 시간이 종료되었을 때, 자동 제출되는 로직

--- a/src/components/exam/TestSubmitOrCancle.tsx
+++ b/src/components/exam/TestSubmitOrCancle.tsx
@@ -38,7 +38,7 @@ const TestSubmitOrCancle = (props: Props) => {
   } = props;
   const [selectedMockExamId, setSelectedMockExamId] = useRecoilState(mockExamIdState);
   // 남은 시간(타이머) TODO: questions[0].mockExam.timeLimit으로 변경
-  const [timeLeft, setTimeLeft] = useState(5400000); //5400000
+  const [timeLeft, setTimeLeft] = useState(10000); //5400000
   // 각 문제당 걸린 시간
   const [time, setTime] = useRecoilState<number>(stopwatchTime);
   const [isRunning, setIsRunning] = useRecoilState<boolean>(stopwatchIsRunning);
@@ -95,6 +95,16 @@ const TestSubmitOrCancle = (props: Props) => {
     calculateScore();
   };
 
+  /**
+   * 시간이 종료되었을 때, 자동 제출되는 로직
+   */
+  useEffect(() => {
+    if (timeLeft <= 0) {
+      setIsRunning(false);
+      setIsAutoSubmitTimeUpModalOpen(!isAutoSubmitTimeUpModalOpen);
+    }
+  }, [timeLeft]);
+
   useEffect(() => {
     if (!isRunning) {
       recordSessionTime();
@@ -129,16 +139,6 @@ const TestSubmitOrCancle = (props: Props) => {
       setSubjectResultList([]); //다시 제출 방지
     }
   }, [subjectResultList]);
-
-  /**
-   * 시간이 종료되었을 때, 자동 제출되는 로직
-   */
-  useEffect(() => {
-    if (timeLeft < 0) {
-      setIsRunning(false);
-      setIsAutoSubmitTimeUpModalOpen(!isAutoSubmitTimeUpModalOpen);
-    }
-  }, [timeLeft]);
 
   return (
     <>

--- a/src/components/exam/TestSubmitOrCancle.tsx
+++ b/src/components/exam/TestSubmitOrCancle.tsx
@@ -12,7 +12,7 @@ import {
   stopwatchIsPaused,
   stopwatchIsRunning,
   stopwatchTime,
-  subjectResultRequestsList, timeLimitState,
+  subjectResultRequestsList, submittedMockExamResultIdState, timeLimitState,
   timerIsPaused,
   userAnswerRequestsList,
 } from '@/recoil/exam/atom';
@@ -59,6 +59,7 @@ const TestSubmitOrCancle = (props: Props) => {
   const minutes = String(Math.floor((timeLeft / (1000 * 60)) % 60)).padStart(2, '0');
   const seconds = String(Math.floor((timeLeft / 1000) % 60)).padStart(2, '0');
   const { calculateScore, prepareAndScoreSubjectResults } = useCalculateScore(selectedMockExamId);
+  const [submittedMockExamResultId, setSubmittedMockExamResultId] = useRecoilState(submittedMockExamResultIdState);
 
   /**
    * 시험 시간 타이머 기능
@@ -116,7 +117,7 @@ const TestSubmitOrCancle = (props: Props) => {
 
   useEffect(() => {
     if (sessionRecorded) {
-      handleSubmit().then((r) => console.log('제출되어 체점 완료'));
+      handleSubmit()
       setSessionRecorded(false); // 다시 초기 상태로 설정
     }
   }, [sessionRecorded]);
@@ -137,7 +138,10 @@ const TestSubmitOrCancle = (props: Props) => {
    */
   useEffect(() => {
     if (subjectResultList.length !== 0) {
-      postSubjectResultRequestsList(subjectResultList, selectedMockExamId).then((r) => console.log('제출 되어야 함.', r));
+      postSubjectResultRequestsList(subjectResultList, selectedMockExamId).then((r) => {
+        console.log(r);
+        setSubmittedMockExamResultId(r.result.mockExamResultId);
+      });
       setSubjectResultList([]); //다시 제출 방지
     }
   }, [subjectResultList]);

--- a/src/components/exam/TestSubmitOrCancle.tsx
+++ b/src/components/exam/TestSubmitOrCancle.tsx
@@ -12,7 +12,7 @@ import {
   stopwatchIsPaused,
   stopwatchIsRunning,
   stopwatchTime,
-  subjectResultRequestsList,
+  subjectResultRequestsList, timeLimitState,
   timerIsPaused,
   userAnswerRequestsList,
 } from '@/recoil/exam/atom';
@@ -37,8 +37,10 @@ const TestSubmitOrCancle = (props: Props) => {
     setIsAutoSubmitTimeUpModalOpen,
   } = props;
   const [selectedMockExamId, setSelectedMockExamId] = useRecoilState(mockExamIdState);
-  // 남은 시간(타이머) TODO: questions[0].mockExam.timeLimit으로 변경
-  const [timeLeft, setTimeLeft] = useState(10000); //5400000
+  //시험 제한 시간
+  const [timeLimit, setTimeLimit] = useRecoilState(timeLimitState);
+  // 남은 시간(타이머)
+  const [timeLeft, setTimeLeft] = useState(timeLimit); //5400000 -> 1시간 30분, 10000 -> 10초
   // 각 문제당 걸린 시간
   const [time, setTime] = useRecoilState<number>(stopwatchTime);
   const [isRunning, setIsRunning] = useRecoilState<boolean>(stopwatchIsRunning);

--- a/src/components/exam/TimerModal.tsx
+++ b/src/components/exam/TimerModal.tsx
@@ -1,54 +1,65 @@
 'use client';
-import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import React, { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 
-import { Session } from '@/types/global';
-import { selectedSessionState } from '@/utils/recoilState';
+import { mockExamIdState } from '@/recoil/exam/atom';
 
 interface SessionModalProps {
+  mockExamId: number;
   closeTimerModal: () => void;
   closeSessionModal: () => void;
+  round: number;
+  timeLimit: number;
 }
 
-const TimerModal: React.FC<SessionModalProps> = ({ closeTimerModal, closeSessionModal }) => {
-  const [selectedSession, setSelectedSession] = useRecoilState<Session | null>(selectedSessionState);
+const TimerModal: React.FC<SessionModalProps> = ({
+  mockExamId,
+  timeLimit,
+  round,
+  closeTimerModal,
+  closeSessionModal,
+}) => {
+  const [selectedMockExamId, setSelectedMockExamId] = useRecoilState(mockExamIdState);
+  const router = useRouter();
   // 타이머 모달이 나타나면 기존 세션 모달을 종료 위한 동작
   useEffect(() => {
     // 타이머 모달이 나타난 후에 실행되는 부분
     closeSessionModal();
   }, [closeSessionModal]);
-  // 체크박스 체크 여부 state
-  const [isChecked, setIsChecked] = useState(false);
-
-  // 체크박스 state 변경 함수
-  const handleCheckboxChange = () => {
-    setIsChecked((prev) => !prev);
-  };
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-30">
+    <div className="fixed z-20 inset-0 flex items-center justify-center bg-black bg-opacity-30">
       <div className="w-[80%]">
         <button onClick={closeTimerModal} className="w-full flex justify-end text-white text-h6 px-2 my-2">
           닫기 X
         </button>
-        <div className="bg-white rounded-3xl">
-          <div className="w-[90%] mx-auto">
-            <h2 className="flex justify-center text-h4 font-bold p-4">
-              <div>{`${selectedSession?.sessionNumber}회차`}</div>
-            </h2>
+        <div className="p-5 bg-white rounded-[32px] flex flex-col gap-y-6">
+          <div className="flex flex-col gap-y-4">
+            <div className="flex justify-center text-h4 font-semibold">{`${round}회차`}</div>
             <div className="border-t border-gray1"></div>
-            <div className="flex justify-center font-bold my-4">시험 시간 설정</div>
-            <div className="flex justify-center rounded-3xl bg-gray1 p-4">여기에 타이머가 들어가야하는데</div>
-            <div className="flex justify-center mt-3">
-              <label className="text-h5">
-                <input className="mx-2" type="checkbox" checked={isChecked} onChange={handleCheckboxChange} />
-              </label>
-              <div className="text-h5">종료 시 소리 알림</div>
-            </div>
-            <div className="flex justify-center">
-              <button className="w-full bg-black text-white rounded-3xl text-h5 p-3 my-4">시험 보기</button>
+            <div className={'flex flex-col gap-y-2'}>
+              <div className="flex justify-center font-semibold">시험 시간 설정</div>
+              <div className="flex gap-x-8 justify-center rounded-[24px] bg-gray0 p-4">
+                <div className={'flex items-end gap-x-[2px]'}>
+                  <span className={'text-h2 font-semibold text-gray3'}>{Math.floor(timeLimit / 3600000)}</span>
+                  <span className={'text-h4 font-normal text-black pb-[3px]'}>시간</span>
+                </div>
+                <div className={'flex items-end gap-x-[2px]'}>
+                  <span className={'text-h2 font-semibold text-gray3'}>{Math.floor(timeLimit / 60000)}</span>
+                  <span className={'text-h4 font-normal text-black pb-[3px]'}>분</span>
+                </div>
+              </div>
             </div>
           </div>
+          <button
+            onClick={() => {
+              setSelectedMockExamId(mockExamId);
+              router.push('/exam/test');
+            }}
+            className="flex justify-center w-full bg-black text-white rounded-3xl text-h5 p-4">
+            시험 보기
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/exam/TimerModal.tsx
+++ b/src/components/exam/TimerModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useRouter } from 'next/navigation';
-import React, { useEffect } from 'react';
+import React, { SVGProps, useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 
 import { mockExamIdState } from '@/recoil/exam/atom';
@@ -31,8 +31,8 @@ const TimerModal: React.FC<SessionModalProps> = ({
   return (
     <div className="fixed z-20 inset-0 flex items-center justify-center bg-black bg-opacity-30">
       <div className="w-[80%]">
-        <button onClick={closeTimerModal} className="w-full flex justify-end text-white text-h6 px-2 my-2">
-          닫기 X
+        <button onClick={closeTimerModal} className="w-full flex items-center justify-end text-white text-h6 px-2 my-2">
+          닫기 <CancleIcon />
         </button>
         <div className="p-5 bg-white rounded-[32px] flex flex-col gap-y-6">
           <div className="flex flex-col gap-y-4">
@@ -67,3 +67,27 @@ const TimerModal: React.FC<SessionModalProps> = ({
 };
 
 export default TimerModal;
+
+const CancleIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} fill="none" {...props}>
+    <mask
+      id="a"
+      width={24}
+      height={24}
+      x={0}
+      y={0}
+      maskUnits="userSpaceOnUse"
+      style={{
+        maskType: 'alpha',
+      }}>
+      <path fill="#D9D9D9" d="M0 0h24v24H0z" />
+    </mask>
+    <g mask="url(#a)">
+      <path
+        fill="#fff"
+        d="m12 12.708-5.246 5.246a.5.5 0 0 1-.344.15.47.47 0 0 1-.364-.15.5.5 0 0 1-.16-.354.5.5 0 0 1 .16-.354L11.292 12 6.046 6.754a.5.5 0 0 1-.15-.344.47.47 0 0 1 .15-.364.5.5 0 0 1 .354-.16.5.5 0 0 1 .354.16L12 11.292l5.246-5.246a.5.5 0 0 1 .344-.15.47.47 0 0 1 .364.15.5.5 0 0 1 .16.354.5.5 0 0 1-.16.354L12.708 12l5.246 5.246a.5.5 0 0 1 .15.344.47.47 0 0 1-.15.364.5.5 0 0 1-.354.16.5.5 0 0 1-.354-.16z"
+      />
+    </g>
+  </svg>
+);
+

--- a/src/components/exam/UserExamAttemptsFilter.tsx
+++ b/src/components/exam/UserExamAttemptsFilter.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { MockExamResultType } from '@/types/exam/type';
+
+interface Props {
+  userExamAttempts: MockExamResultType[] | null;
+  setUserExamAttempt: React.Dispatch<React.SetStateAction<number>>;
+  isClickedActionIcon: boolean;
+  setIsClickedActionIcon: React.Dispatch<React.SetStateAction<boolean>>;
+}
+const UserExamAttemptsFilter = (props: Props) => {
+  const { userExamAttempts, setUserExamAttempt, isClickedActionIcon, setIsClickedActionIcon } = props;
+  return (
+    <div
+      className={
+        'absolute top-[26%] w-[90%] overflow-y-scroll h-[200px] border-[1px] border-gray2 bg-white rounded-[16px] py-2 z-10'
+      }>
+      {!userExamAttempts || userExamAttempts.length === 0 ? (
+        <div>error</div>
+      ) : (
+        userExamAttempts.map((userExamAttempt: MockExamResultType, index: number) => {
+          return (
+            <div
+              key={index}
+              className="text-h4 text-gray3 py-3 px-4 hover:text-black transition"
+              onClick={() => {
+                setUserExamAttempt(index + 1);
+                setIsClickedActionIcon(!isClickedActionIcon);
+              }}>
+              {index + 1}회차
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+};
+export default UserExamAttemptsFilter;

--- a/src/components/exam/UserExamAttemptsFilterContent.tsx
+++ b/src/components/exam/UserExamAttemptsFilterContent.tsx
@@ -1,0 +1,46 @@
+import { SVGProps, useState } from 'react';
+import React from 'react';
+
+import UserExamAttemptsFilter from '@/components/exam/UserExamAttemptsFilter';
+import { MockExamResultType } from '@/types/exam/type';
+
+interface Props {
+  userExamAttempts: MockExamResultType[] | null;
+  userExamAttempt: number;
+  setUserExamAttempt: React.Dispatch<React.SetStateAction<number>>;
+}
+const UserExamAttemptsFilterContent = (props: Props) => {
+  const { userExamAttempts, userExamAttempt, setUserExamAttempt } = props;
+  const [isClickedActionIcon, setIsClickedActionIcon] = useState<boolean>(false);
+  return (
+    <>
+      <div className={'text-h3 font-semibold'}>모의고사 응시횟수 선택</div>
+      <div
+        onClick={() => setIsClickedActionIcon(!isClickedActionIcon)}
+        className={'mt-2 my-5 py-3 px-4 bg-white flex justify-between rounded-[16px]'}>
+        {userExamAttempt + 1}회{isClickedActionIcon ? <ActionIcon /> : <InactiveIcon />}
+      </div>
+      {isClickedActionIcon ? (
+        <UserExamAttemptsFilter
+          userExamAttempts={userExamAttempts}
+          setUserExamAttempt={setUserExamAttempt}
+          setIsClickedActionIcon={setIsClickedActionIcon}
+          isClickedActionIcon={isClickedActionIcon}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default UserExamAttemptsFilterContent;
+
+const InactiveIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={21} height={21} fill="none" {...props}>
+    <path stroke="#000" strokeLinecap="round" d="m14.208 9-3.5 3-3.5-3" />
+  </svg>
+);
+const ActionIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={21} height={21} fill="none" {...props}>
+    <path stroke="#000" strokeLinecap="round" d="m7.208 12 3.5-3 3.5 3" />
+  </svg>
+);

--- a/src/components/exam/YearSelector.tsx
+++ b/src/components/exam/YearSelector.tsx
@@ -6,11 +6,16 @@ import * as React from 'react';
 import MockExamYearsFilter from '@/components/exam/MockExamYearsFilter';
 import useGetMockExamYears from '@/lib/hooks/useGetMockExamYears';
 
+interface Props {
+  examYears: number[];
+  isClickedYearSelector: boolean;
+  setIsClickedYearSelector: React.Dispatch<React.SetStateAction<boolean>>;
+  selectedYear: number;
+  setSelectedYear: React.Dispatch<React.SetStateAction<number>>;
+}
 // 과목의 Year를 선택하는 모듈
-const YearSelector = () => {
-  const { examYears } = useGetMockExamYears('YearSelector');
-  const [isClickedYearSelector, setIsClickedYearSelector] = useState<boolean>(false);
-  const [selectedYear, setSelectedYear] = useState<number>(2017);
+const YearSelector = (props: Props) => {
+  const { examYears, isClickedYearSelector, setSelectedYear, setIsClickedYearSelector, selectedYear } = props;
 
   return (
     <>

--- a/src/components/exam/YearSelector.tsx
+++ b/src/components/exam/YearSelector.tsx
@@ -1,60 +1,47 @@
 'use client';
-import React, { useEffect } from 'react';
-import { useRecoilState } from 'recoil';
 
-import { useGetExamInfoData } from '@/lib/hooks/ExamInfoFetcher';
-import { examYearList } from '@/types/global';
-import { YearState } from '@/utils/recoilState';
+import { SVGProps, useState } from 'react';
+import * as React from 'react';
+
+import MockExamYearsFilter from '@/components/exam/MockExamYearsFilter';
+import useGetMockExamYears from '@/lib/hooks/useGetMockExamYears';
 
 // 과목의 Year를 선택하는 모듈
-const YearSelector = ({}) => {
-  // 과목의 연도의 상태를 관리하는 state
-  const [selectedYear, setSelectedYear] = useRecoilState<Number | undefined>(YearState);
-  const { Data } = useGetExamInfoData();
-
-  // year정보만 추출하기
-  // const yearKeys = Object.keys(Data?.result?.examYearWithRounds || {});
-  const yearKeys = ['2020', '2021', '2023'];
-  // 추출한 데이터 정수형으로 변환하기
-  const yearsAsIntegers = yearKeys.map((year) => parseInt(year, 10));
-
-  // 연도 리스트가 들어간거임
-  const examYears: examYearList = {
-    years: yearsAsIntegers,
-  };
-
-  // 받아온 연도에 첫번째로 set
-  const defaultYear = examYears.years[0] || undefined;
-
-  // selectbox에 들어갈 년도 배열 정립
-  const uniqueYears = examYears.years || null;
-
-  useEffect(() => {
-    setSelectedYear(defaultYear);
-  }, [setSelectedYear, defaultYear]);
-
-  // 연도 변경하여 상태에 저장하는 함수
-  const handleSubjectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const selectedYear = parseInt(event.target.value, 10);
-    setSelectedYear(selectedYear);
-  };
+const YearSelector = () => {
+  const { examYears } = useGetMockExamYears('YearSelector');
+  const [isClickedYearSelector, setIsClickedYearSelector] = useState<boolean>(false);
+  const [selectedYear, setSelectedYear] = useState<number>(2017);
 
   return (
-    <div className="mt-2">
-      <select
-        id="subject"
-        name="subject"
-        value={selectedYear?.toString() || ''}
-        onChange={handleSubjectChange}
-        className="mx-auto mt-1 text-h4 font-bold block w-[95%] p-3 bg-gray0 rounded-xl shadow-sm focus:outline-none focus:ring focus:border-blue-300 sm:text-sm">
-        {uniqueYears.map((year, index) => (
-          <option key={index} value={year}>
-            {year}년 기출 모의고사
-          </option>
-        ))}
-      </select>
-    </div>
+    <>
+      <div
+        onClick={() => {
+          setIsClickedYearSelector(!isClickedYearSelector);
+        }}
+        className={'mt-2 flex justify-between items-center bg-gray0 rounded-[16px] py-3 px-4'}>
+        <span>{selectedYear}년도 기출 모의고사</span>
+        {isClickedYearSelector ? <ActiveIcon /> : <DisableIcon />}
+      </div>
+      {isClickedYearSelector ? (
+        <MockExamYearsFilter
+          setIsClickedYearSelector={setIsClickedYearSelector}
+          setSelectedYear={setSelectedYear}
+          yearList={examYears}
+        />
+      ) : null}
+    </>
   );
 };
 
 export default YearSelector;
+
+const DisableIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={20} height={20} fill="none" {...props}>
+    <path stroke="#000" strokeLinecap="round" d="m13.5 8.5-3.5 3-3.5-3" />
+  </svg>
+);
+const ActiveIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={20} height={20} fill="none" {...props}>
+    <path stroke="#000" strokeLinecap="round" d="m6.5 11.5 3.5-3 3.5 3" />
+  </svg>
+);

--- a/src/hooks/useCalculateScore.tsx
+++ b/src/hooks/useCalculateScore.tsx
@@ -7,10 +7,10 @@ import { SubjectResultRequests, UserAnswerRequests } from '@/types/global';
 /**
  * 채점해주는 커스텀 훅
  */
-const useCalculateScore = () => {
+const useCalculateScore = (mockExamId: number) => {
   const [userAnswerList, setUserAnswerList] = useRecoilState<UserAnswerRequests[]>(userAnswerRequestsList);
   const [subjectResultList, setSubjectResultList] = useRecoilState(subjectResultRequestsList);
-  const { questions, isLoading, isError } = useMockExamQuestions();
+  const { questions, isLoading, isError } = useMockExamQuestions(mockExamId);
 
   /**
    * 사용자가 선택한 각 선택지가 맞았는지 틀렸는지 채점

--- a/src/lib/api/exam.ts
+++ b/src/lib/api/exam.ts
@@ -1,7 +1,10 @@
 import { sendRequest } from '@/lib/axios';
 import { SubjectResultRequests } from '@/types/global';
 
-export const postSubjectResultRequestsList = async (subjectResultRequestsList: SubjectResultRequests[]) => {
+export const postSubjectResultRequestsList = async (
+  subjectResultRequestsList: SubjectResultRequests[],
+  mockExamId: number,
+) => {
   try {
     // 액세스 토큰을 헤더에 담아 요청 보내기
     const response = await sendRequest({
@@ -10,7 +13,7 @@ export const postSubjectResultRequestsList = async (subjectResultRequestsList: S
       },
       method: 'POST',
       data: { createSubjectResultRequests: subjectResultRequestsList },
-      url: 'mock-exams/1/mock-exam-results',
+      url: `mock-exams/${mockExamId}/mock-exam-results`,
     });
     // 성공적인 응답 처리
     return response.data;

--- a/src/lib/hooks/AccuracyChart.tsx
+++ b/src/lib/hooks/AccuracyChart.tsx
@@ -12,11 +12,13 @@ const AccuracyChart = (props: Props) => {
   const [subjectData, setSubjectData] = useState<CorrectRateGraphType[]>([]);
 
   useEffect(() => {
-    const transformedData: CorrectRateGraphType[] = subjectResults.map((result) => ({
-      subjectTitle: result.subject.subjectName,
-      subjectCorrectRate: result.correctRate,
-    }));
-    setSubjectData(transformedData);
+    if (subjectResults) {
+      const transformedData: CorrectRateGraphType[] = subjectResults.map((result) => ({
+        subjectTitle: result.subject.subjectName,
+        subjectCorrectRate: result.correctRate,
+      }));
+      setSubjectData(transformedData);
+    }
   }, [subjectResults]);
 
   return (
@@ -29,12 +31,12 @@ const AccuracyChart = (props: Props) => {
           indexBy="subjectTitle"
           valueFormat=" >-.2f"
           margin={{ top: 30, right: 70, bottom: 0, left: 70 }}
-          maxValue={subjectResults[0].subject.totalScore} // 최댓값을 부여할지 말지 고민
+          // maxValue={subjectResults[0].subject.totalScore} // 최댓값을 부여할지 말지 고민
           borderWidth={1}
           borderColor="#3B3DFF"
           gridShape="linear"
           gridLabelOffset={13}
-          dotLabelYOffset={-2}
+          dotLabelYOffset={-3}
           enableDots={true}
           dotSize={2}
           enableDotLabel={true}

--- a/src/lib/hooks/AccuracyChart.tsx
+++ b/src/lib/hooks/AccuracyChart.tsx
@@ -1,0 +1,54 @@
+import { ResponsiveRadar } from '@nivo/radar';
+import { useEffect, useState } from 'react';
+
+import { CorrectRateGraphType, SubjectResultsType } from '@/types/exam/type';
+
+interface Props {
+  subjectResults: SubjectResultsType[];
+}
+const AccuracyChart = (props: Props) => {
+  const { subjectResults } = props;
+
+  const [subjectData, setSubjectData] = useState<CorrectRateGraphType[]>([]);
+
+  useEffect(() => {
+    const transformedData: CorrectRateGraphType[] = subjectResults.map((result) => ({
+      subjectTitle: result.subject.subjectName,
+      subjectCorrectRate: result.correctRate,
+    }));
+    setSubjectData(transformedData);
+  }, [subjectResults]);
+
+  return (
+    <div className={'bg-white rounded-[32px]'}>
+      <div className={'font-semibold px-5 mt-5 text-h3'}>과목별 정답률</div>
+      <div className={'w-full'} style={{ height: '280px' }}>
+        <ResponsiveRadar
+          data={subjectData}
+          keys={['subjectCorrectRate']}
+          indexBy="subjectTitle"
+          valueFormat=" >-.2f"
+          margin={{ top: 30, right: 70, bottom: 0, left: 70 }}
+          maxValue={subjectResults[0].subject.totalScore} // 최댓값을 부여할지 말지 고민
+          borderWidth={1}
+          borderColor="#3B3DFF"
+          gridShape="linear"
+          gridLabelOffset={13}
+          dotLabelYOffset={-2}
+          enableDots={true}
+          dotSize={2}
+          enableDotLabel={true}
+          dotBorderColor={{ theme: 'background' }}
+          dotColor={{ theme: 'background' }}
+          dotBorderWidth={2}
+          dotLabel="value"
+          colors={{ scheme: 'blues', size: 5 }}
+          fillOpacity={1}
+          blendMode="multiply"
+          motionConfig="wobbly"
+        />
+      </div>
+    </div>
+  );
+};
+export default AccuracyChart;

--- a/src/lib/hooks/ExamInfoFetcher.ts
+++ b/src/lib/hooks/ExamInfoFetcher.ts
@@ -1,4 +1,3 @@
-import { AxiosResponse } from 'axios';
 import useSWR from 'swr';
 
 import { client, swrGetFetcher } from '@/lib/axios';

--- a/src/lib/hooks/useGetExamResultRecent.tsx
+++ b/src/lib/hooks/useGetExamResultRecent.tsx
@@ -1,0 +1,18 @@
+import useSWR from 'swr';
+
+import { swrGetFetcher } from '@/lib/axios';
+import { RecentMockExamResultResponseType } from '@/types/exam/type';
+
+const useGetExamResultRecent = (mockExamId: number) => {
+  const { data, error } = useSWR<RecentMockExamResultResponseType>(
+    `/mock-exams/${mockExamId}/mock-exam-results/recent`,
+    swrGetFetcher,
+  );
+
+  return {
+    examResultRecent: data ? data.result : false,
+    isLoading: !error && !data,
+    isError: error,
+  };
+};
+export default useGetExamResultRecent;

--- a/src/lib/hooks/useGetExamResults.tsx
+++ b/src/lib/hooks/useGetExamResults.tsx
@@ -1,0 +1,17 @@
+import useSWR from 'swr';
+
+import { swrGetFetcher } from '@/lib/axios';
+import { MockExamResultsResponseType, MockExamResultType } from '@/types/exam/type';
+
+const useGetExamResults = (mockExamId: number) => {
+  const { data, error } = useSWR<MockExamResultsResponseType>(`/mock-exams/${mockExamId}`, swrGetFetcher);
+
+  const parseResultList = data?.result.map((item: MockExamResultType) => item).flat();
+
+  return {
+    examResults: data ? parseResultList : null,
+    isLoading: !error && !data,
+    isError: error,
+  };
+};
+export default useGetExamResults;

--- a/src/lib/hooks/useGetIncorrectQuestionsResult.tsx
+++ b/src/lib/hooks/useGetIncorrectQuestionsResult.tsx
@@ -1,0 +1,37 @@
+import useSWRInfinite from 'swr/infinite';
+
+import { swrGetFetcher } from '@/lib/axios';
+import { MockExamIncorrectQuestionsResultResponseType } from '@/types/exam/type';
+import { ReviewIncorrectAnswers } from '@/types/global';
+
+const getKey = (size: number, previousPageData: ReviewIncorrectAnswers, mockExamResultId: number) => {
+  if (size === 0) {
+    return `/mock-exam-results/${mockExamResultId}/user-answers/wrong-answers?page=${size}&size=10&sortFields=subjectResultEntity.mockExamResultEntity.createdAt, questionEntity.questionSeq&sortDirections=DESC, ASC`;
+  }
+  if (previousPageData && !previousPageData.result.last) {
+    return `/mock-exam-results/${mockExamResultId}/user-answers/wrong-answers?page=${size}&size=10&sortFields=subjectResultEntity.mockExamResultEntity.createdAt, questionEntity.questionSeq&sortDirections=DESC, ASC`;
+  }
+  if (previousPageData.result.last) {
+    return null;
+  }
+};
+const useGetIncorrectQuestionsResult = (mockExamResultId: number) => {
+  const { data, isLoading, error, size, setSize } = useSWRInfinite<MockExamIncorrectQuestionsResultResponseType>(
+    (pageIndex, previousPageData) => getKey(pageIndex, previousPageData, mockExamResultId),
+    swrGetFetcher,
+    {
+      revalidateAll: true,
+    },
+  );
+
+  const parseResultList = data ? data.map((item) => item).flat() : null;
+
+  return {
+    incorrectQuestionsResult: parseResultList ? parseResultList : [],
+    isLoading: !error && !data,
+    isError: error,
+    size,
+    setSize,
+  };
+};
+export default useGetIncorrectQuestionsResult;

--- a/src/lib/hooks/useGetMockExamYears.tsx
+++ b/src/lib/hooks/useGetMockExamYears.tsx
@@ -1,14 +1,18 @@
 import { AxiosResponse } from 'axios';
+import { useEffect } from 'react';
 import useSWR from 'swr';
 
 import { swrGetFetcher } from '@/lib/axios';
-import { useEffect } from 'react';
 
-const useGetMockExamYears = () => {
+const useGetMockExamYears = (usage: string) => {
   const { data, error } = useSWR<AxiosResponse>('/certificates/1/exam-years', swrGetFetcher);
 
+  /**
+   * 사용된 컴포넌트에 따라 초기화 값을 다르게 하도록 하는 트릭
+   * CommentaryBoardList 일 때만 전체가 초기화 되도록 구현
+   */
   useEffect(() => {
-    if (data && Array.isArray(data?.result) && !data?.result.includes('전체')) {
+    if (usage == 'CommentaryBoardList' && data && Array.isArray(data?.result) && !data?.result.includes('전체')) {
       data.result.unshift('전체');
     }
   }, [data]);

--- a/src/lib/hooks/useGetMockExams.tsx
+++ b/src/lib/hooks/useGetMockExams.tsx
@@ -6,7 +6,7 @@ import { swrGetFetcher } from '@/lib/axios';
 const useGetMockExams = (certificateId: number, year: number | string) => {
   const { data, error } = useSWR<AxiosResponse>(
     year === '전체'
-      ? `/certificates/${certificateId}/mock-exams?examYear=2023`
+      ? `/certificates/${certificateId}/mock-exams?examYear=2017`
       : `/certificates/${certificateId}/mock-exams?examYear=${year}`,
     swrGetFetcher,
   );

--- a/src/lib/hooks/useGetTestResults.tsx
+++ b/src/lib/hooks/useGetTestResults.tsx
@@ -3,7 +3,7 @@ import useSWR from 'swr';
 import { swrGetFetcher } from '@/lib/axios';
 import { MockExamResultsResponseType, MockExamResultType } from '@/types/exam/type';
 
-const useGetExamResults = (mockExamId: number) => {
+const useGetTestResults = (mockExamId: number) => {
   const { data, error } = useSWR<MockExamResultsResponseType>(`/mock-exams/${mockExamId}`, swrGetFetcher);
 
   const parseResultList = data?.result.map((item: MockExamResultType) => item).flat();
@@ -14,4 +14,4 @@ const useGetExamResults = (mockExamId: number) => {
     isError: error,
   };
 };
-export default useGetExamResults;
+export default useGetTestResults;

--- a/src/lib/hooks/useMockExamQuestions.tsx
+++ b/src/lib/hooks/useMockExamQuestions.tsx
@@ -4,8 +4,8 @@ import useSWR from 'swr';
 import { swrGetFetcher } from '@/lib/axios';
 import { Certificate, QuestionsResponse } from '@/types/global';
 
-const useGetGoalSettingData = () => {
-  const { data, error } = useSWR<AxiosResponse>('/mock-exams/1/questions', swrGetFetcher);
+const useGetGoalSettingData = (mockExamId: number) => {
+  const { data, error } = useSWR<AxiosResponse>(`/mock-exams/${mockExamId}/questions`, swrGetFetcher);
 
   const parseResultList: QuestionsResponse[] = data?.result.map((item) => item).flat();
 

--- a/src/recoil/exam/atom.ts
+++ b/src/recoil/exam/atom.ts
@@ -77,3 +77,8 @@ export const timeLimitState = atom<number>({
   key: 'timeLimitState',
   default: 0,
 });
+
+export const submittedMockExamResultIdState = atom<number>({
+  key: 'submittedMockExamResultIdState',
+  default: 0,
+});

--- a/src/recoil/exam/atom.ts
+++ b/src/recoil/exam/atom.ts
@@ -72,3 +72,8 @@ export const mockExamIdState = atom<number>({
   key: 'mockExamIdState',
   default: 1,
 });
+
+export const timeLimitState = atom<number>({
+  key: 'timeLimitState',
+  default: 0,
+});

--- a/src/recoil/exam/atom.ts
+++ b/src/recoil/exam/atom.ts
@@ -37,6 +37,11 @@ export let userAnswerRequestsList = atom<UserAnswerRequests[]>({
   default: [],
 });
 
+export const sessionRecordedState = atom<boolean>({
+  key: 'sessionRecordedState',
+  default: false,
+});
+
 export const questionIndex = atom<number>({
   key: 'questionIndex',
   default: 0,

--- a/src/recoil/exam/atom.ts
+++ b/src/recoil/exam/atom.ts
@@ -61,3 +61,9 @@ export const stopwatchIsPaused = atom<boolean>({
   key: 'stopwatchIsPaused',
   default: false,
 });
+
+//모의고사 응시 번호
+export const mockExamIdState = atom<number>({
+  key: 'mockExamIdState',
+  default: 1,
+});

--- a/src/types/exam/type.ts
+++ b/src/types/exam/type.ts
@@ -24,7 +24,7 @@ export interface MockExamResultType {
   totalScore: number;
 }
 
-interface SubjectResultsType {
+export interface SubjectResultsType {
   subject: Subject;
   score: number;
   numberOfCorrect: number;

--- a/src/types/exam/type.ts
+++ b/src/types/exam/type.ts
@@ -1,4 +1,4 @@
-import { ReviewIncorrectMockExam, Subject } from '@/types/global';
+import { Question, ReviewIncorrectMockExam, Subject } from '@/types/global';
 export interface RecentMockExamResultResponseType {
   responseCode: string;
   result: RecentMockExamResultType;
@@ -11,6 +11,9 @@ interface RecentMockExamResultType {
   createdAt: string;
 }
 
+/**
+ * 성적리포트 통계 responseType
+ */
 export interface MockExamResultsResponseType {
   responseCode: string;
   result: MockExamResultType[];
@@ -30,4 +33,23 @@ export interface SubjectResultsType {
   numberOfCorrect: number;
   totalTakenTime: number;
   correctRate: number;
+}
+
+/**
+ * 성적리포트 틀린문제 responseType
+ */
+export interface MockExamIncorrectQuestionsResultResponseType {
+  responseCode: string;
+  result: {
+    content: MockExamIncorrectQuestionsResult[];
+    hasNext: boolean;
+  };
+}
+
+export interface MockExamIncorrectQuestionsResult {
+  question: Question;
+  userAnswerId: number;
+  selectOptionSeq: number;
+  takenTime: number;
+  isCorrect: boolean;
 }

--- a/src/types/exam/type.ts
+++ b/src/types/exam/type.ts
@@ -53,3 +53,8 @@ export interface MockExamIncorrectQuestionsResult {
   takenTime: number;
   isCorrect: boolean;
 }
+
+export interface CorrectRateGraphType {
+  subjectTitle: string;
+  subjectCorrectRate: number;
+}

--- a/src/types/exam/type.ts
+++ b/src/types/exam/type.ts
@@ -1,0 +1,12 @@
+import { ReviewIncorrectMockExam } from '@/types/global';
+export interface RecentMockExamResultResponseType {
+  responseCode: string;
+  result: RecentMockExamResultType
+}
+interface RecentMockExamResultType {
+  mockExamResultId: number;
+  round: number;
+  mockExam: ReviewIncorrectMockExam;
+  totalScore: number;
+  createdAt: string;
+}

--- a/src/types/exam/type.ts
+++ b/src/types/exam/type.ts
@@ -1,7 +1,7 @@
-import { ReviewIncorrectMockExam } from '@/types/global';
+import { ReviewIncorrectMockExam, Subject } from '@/types/global';
 export interface RecentMockExamResultResponseType {
   responseCode: string;
-  result: RecentMockExamResultType
+  result: RecentMockExamResultType;
 }
 interface RecentMockExamResultType {
   mockExamResultId: number;
@@ -9,4 +9,25 @@ interface RecentMockExamResultType {
   mockExam: ReviewIncorrectMockExam;
   totalScore: number;
   createdAt: string;
+}
+
+export interface MockExamResultsResponseType {
+  responseCode: string;
+  result: MockExamResultType[];
+}
+
+export interface MockExamResultType {
+  mockExamResultId: number;
+  round: number;
+  mockExam: ReviewIncorrectMockExam;
+  subjectResults: SubjectResultsType[];
+  totalScore: number;
+}
+
+interface SubjectResultsType {
+  subject: Subject;
+  score: number;
+  numberOfCorrect: number;
+  totalTakenTime: number;
+  correctRate: number;
 }

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -367,7 +367,7 @@ interface Question {
   subject: Subject;
   questionSeq: number;
   questionText: string;
-  questionImage: string;
+  questionImage?: string;
   questionOptions: QuestionOptions[];
   correctOption: number;
   score: number;


### PR DESCRIPTION
Closes #116 
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

- 모의고사 결과 페이지(성적리포트)를 구현하였습니다.
  - 틀린 문제 모아보기(IncorrectQustion) 컴포넌트를 사용하여 틀린 문제들을 모아보는 기능을 구현하였습니다.
  - nivo.rocks/radar 라이브러리를 사용하여 정답률 그래프 기능을 구현하였습니다.(기존에 상호 오빠 라이브러리를 사용하려 하였으나 조금 더 디자인과 유사한 라이브러리가 없는지 서치하다 발견하여 해당 라이브러리로 기능을 구현하였습니다.)
  - 기존에 모의고사 시간 체크하는 부분에서 1초에 1ms가 측정되어 머문시간 측정이 제대로 되지 않는 문제가 발생하여 이를 1초에 1초씩 가도록 수정하였습니다.
  - 제출 문제가 발생하여 수정하였습니다. 

## ✅ PR Point

**[새로운 지식]**
- 데이터 값이 불러와지면 state값을 처음 설정하고 그 뒤로 state값을 setState가 변경될 때만 state값이 변경되도록 하려면
`const { examResults } = useGetTestResults(mockExamId);`
`const [isInitialLoad, setIsInitialLoad] = useState<boolean>(true);`

 ```
 useEffect(() => {
    if (examResults && examResults.length > 0 && isInitialLoad) {
      setUserExamAttempt(examResults.length);
      setIsInitialLoad(false); // 초기화 완료 후 상태 업데이트
    }
  }, [examResults, isInitialLoad]);
```

이런식으로 초기화 할 때만 useEffect를 사용하도록 isInitialLoad라는 트리거를 사용하여 기능을 구현하였습니다.

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
