### PR TITLE
[ #117] 체점 에러

### DIFF
--- a/src/app/(main)/exam/test/page.tsx
+++ b/src/app/(main)/exam/test/page.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import AutoSubmitTimeUpModal from '@/components/exam/AutoSubmitTimeUpModal';
 import Question from '@/components/exam/Question';
 import SubmitConfirmationModal from '@/components/exam/SubmitConfirmationModal';
-import TestSubmitOrCancle from '@/components/exam/TestSubmitOrCancle';
+import TestSubmitOrCancel from '@/components/exam/TestSubmitOrCancle';
 import UnsavedChangesWarningModal from '@/components/exam/UnsavedChangesWarningModal';
 
 const Test = () => {
@@ -41,7 +41,7 @@ const Test = () => {
         ) : null}
 
         {/*Header*/}
-        <TestSubmitOrCancle
+        <TestSubmitOrCancel
           isUnsavedChangesWarningModalOpen={isUnsavedChangesWarningModalOpen}
           setIsUnsavedChangesWarningModalOpen={setIsUnsavedChangesWarningModalOpen}
           isSubmitConfirmationModalOpen={isSubmitConfirmationModalOpen}

--- a/src/components/exam/AllQuestionModal.tsx
+++ b/src/components/exam/AllQuestionModal.tsx
@@ -8,10 +8,11 @@ import { UserAnswerRequests } from '@/types/global';
 
 interface AllQuestionModalProps {
   toggleQuestionModal: () => void;
+  recordSessionTime: () => void;
 }
 
 export const AllQuestionModal = (props: AllQuestionModalProps) => {
-  const { toggleQuestionModal } = props;
+  const { toggleQuestionModal, recordSessionTime } = props;
 
   const [userAnswerList, setUserAnswerList] = useRecoilState<UserAnswerRequests[]>(userAnswerRequestsList);
   const [questionIdx, setQuestionIdx] = useRecoilState<number>(questionIndex);
@@ -47,6 +48,7 @@ export const AllQuestionModal = (props: AllQuestionModalProps) => {
                         key={userAnswer.questionId}
                         onClick={() => {
                           setQuestionIdx(userAnswer.questionId - 1);
+                          recordSessionTime();
                           toggleQuestionModal();
                         }}
                         className={'flex justify-center items-center bg-[#6283FD]/30 w-12 h-12 rounded-[8px]'}>
@@ -57,6 +59,7 @@ export const AllQuestionModal = (props: AllQuestionModalProps) => {
                         key={userAnswer.questionId}
                         onClick={() => {
                           setQuestionIdx(userAnswer.questionId - 1);
+                          recordSessionTime();
                           toggleQuestionModal();
                         }}
                         className={'flex justify-center items-center bg-second text-white w-12 h-12 rounded-[8px]'}>

--- a/src/components/exam/AutoSubmitTimeUpModal.tsx
+++ b/src/components/exam/AutoSubmitTimeUpModal.tsx
@@ -4,7 +4,7 @@ import { useRecoilState } from 'recoil';
 
 import {
   questionIndex,
-  subjectResultRequestsList,
+  subjectResultRequestsList, timerIsPaused,
   userAnswerRequests,
   userAnswerRequestsList,
 } from '@/recoil/exam/atom';
@@ -18,6 +18,8 @@ interface Props {
 const AutoSubmitTimeUpModal = (props: Props) => {
   const { isAutoSubmitTimeUpModalOpen, setIsAutoSubmitTimeUpModalOpen } = props;
   const router = useRouter();
+  // 모달창을 띄우면 타이머를 잠시 멈추게 하는 state
+  const [isPausedTimer, setIsPausedTimer] = useRecoilState(timerIsPaused);
   const [userAnswerList, setUserAnswerList] = useRecoilState<UserAnswerRequests[]>(userAnswerRequestsList);
   const [subjectResultList, setSubjectResultList] = useRecoilState(subjectResultRequestsList);
   // 현재 머물고 있는 문제 번호
@@ -48,6 +50,7 @@ const AutoSubmitTimeUpModal = (props: Props) => {
           <div className={'flex justify-end gap-x-2'}>
             <button
               onClick={() => {
+                setIsPausedTimer(!isPausedTimer);
                 //체점 결과 초기화
                 setUserAnswerList([]);
                 setSubjectResultList([]);

--- a/src/components/exam/AutoSubmitTimeUpModal.tsx
+++ b/src/components/exam/AutoSubmitTimeUpModal.tsx
@@ -4,7 +4,8 @@ import { useRecoilState } from 'recoil';
 
 import {
   questionIndex,
-  subjectResultRequestsList, timerIsPaused,
+  subjectResultRequestsList,
+  timerIsPaused,
   userAnswerRequests,
   userAnswerRequestsList,
 } from '@/recoil/exam/atom';

--- a/src/components/exam/AutoSubmitTimeUpModal.tsx
+++ b/src/components/exam/AutoSubmitTimeUpModal.tsx
@@ -50,7 +50,7 @@ const AutoSubmitTimeUpModal = (props: Props) => {
           <div className={'flex justify-end gap-x-2'}>
             <button
               onClick={() => {
-                setIsPausedTimer(!isPausedTimer);
+                setIsPausedTimer(true);
                 //체점 결과 초기화
                 setUserAnswerList([]);
                 setSubjectResultList([]);

--- a/src/components/exam/Question.tsx
+++ b/src/components/exam/Question.tsx
@@ -236,7 +236,9 @@ const Question = () => {
         )}
 
         {/* 문제 전체 모아보기 session */}
-        {allQuestionModalIsOpen ? <AllQuestionModal toggleQuestionModal={toggleQuestionModal} /> : null}
+        {allQuestionModalIsOpen ? (
+          <AllQuestionModal toggleQuestionModal={toggleQuestionModal} recordSessionTime={recordSessionTime} />
+        ) : null}
       </div>
     </>
   );

--- a/src/components/exam/Question.tsx
+++ b/src/components/exam/Question.tsx
@@ -79,10 +79,12 @@ const Question = () => {
 
   const resetOptionOnReclick = () => {
     if (userAnswer.selectOptionSeq === userAnswerList[questionIdx]?.selectOptionSeq) {
-      setUserAnswer((prevState) => ({
-        ...prevState,
-        selectOptionSeq: 0,
-      }));
+      if (userAnswerList[questionIdx]?.selectOptionSeq !== 0 && userAnswer.selectOptionSeq !== 0) {
+        setUserAnswer((prevState) => ({
+          ...prevState,
+          selectOptionSeq: 0,
+        }));
+      }
     }
   };
 
@@ -129,6 +131,9 @@ const Question = () => {
 
   useEffect(() => {
     updateUserAnswerInUserAnswerList();
+  }, [userAnswer]);
+
+  useEffect(() => {
     resetOptionOnReclick();
   }, [userAnswer]);
 

--- a/src/components/exam/SubjectList.tsx
+++ b/src/components/exam/SubjectList.tsx
@@ -22,7 +22,7 @@ const SubjectSessionCard = (props: Props) => {
               timeLimit={mockExam.timeLimit}
               total={300}
               round={mockExam.round}
-              mockExamId={mockExam.MockExamId}></SubjectCard>
+              mockExamId={mockExam.mockExamId}></SubjectCard>
           </div>
         );
       })}

--- a/src/components/exam/SubjectList.tsx
+++ b/src/components/exam/SubjectList.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import SubjectCard from '@/components/exam/SubjectCard';
 import useGetMockExams from '@/lib/hooks/useGetMockExams';

--- a/src/components/exam/SubmitConfirmationModal.tsx
+++ b/src/components/exam/SubmitConfirmationModal.tsx
@@ -59,6 +59,7 @@ const SubmitConfirmationModal = (props: Props) => {
             </button>
             <button
               onClick={async () => {
+                setIsPausedTimer(!isPausedTimer);
                 setIsRunning(false); //제출 트릭
                 // 체점 결과 초기화
                 setIsSubmitConfirmationModalOpen(!isSubmitConfirmationModalOpen);

--- a/src/components/exam/SubmitConfirmationModal.tsx
+++ b/src/components/exam/SubmitConfirmationModal.tsx
@@ -50,7 +50,7 @@ const SubmitConfirmationModal = (props: Props) => {
           <div className={'flex justify-end gap-x-2'}>
             <button
               onClick={() => {
-                setIsPausedTimer(!isPausedTimer);
+                setIsPausedTimer(false);
                 setIsPausedStopWatch(!isPausedStopWatch);
                 setIsSubmitConfirmationModalOpen(!isSubmitConfirmationModalOpen);
               }}
@@ -59,7 +59,7 @@ const SubmitConfirmationModal = (props: Props) => {
             </button>
             <button
               onClick={async () => {
-                setIsPausedTimer(!isPausedTimer);
+                setIsPausedTimer(true);
                 setIsRunning(false); //제출 트릭
                 // 체점 결과 초기화
                 setIsSubmitConfirmationModalOpen(!isSubmitConfirmationModalOpen);

--- a/src/components/exam/TestSubmitOrCancle.tsx
+++ b/src/components/exam/TestSubmitOrCancle.tsx
@@ -136,7 +136,6 @@ const TestSubmitOrCancle = (props: Props) => {
   useEffect(() => {
     if (userAnswerList.some((answer) => answer.isCorrect !== undefined)) {
       prepareAndScoreSubjectResults().then(() => {
-        console.log('과목별 모의고사 체점', subjectResultList, userAnswerList);
       });
     }
   }, [userAnswerList]);

--- a/src/components/exam/TestSubmitOrCancle.tsx
+++ b/src/components/exam/TestSubmitOrCancle.tsx
@@ -147,8 +147,6 @@ const TestSubmitOrCancle = (props: Props) => {
    */
   useEffect(() => {
     if (subjectResultList.length !== 0) {
-      console.log('제출될 때 subjectResultList', subjectResultList);
-      console.log('선택된 모의고사 id', selectedMockExamId);
       postSubjectResultRequestsList(subjectResultList, selectedMockExamId).then((r) => {
         console.log(r);
         setSubmittedMockExamResultId(r.result.mockExamResultId);
@@ -172,7 +170,7 @@ const TestSubmitOrCancle = (props: Props) => {
         <button
           className={'border-primary-button'}
           onClick={() => {
-            setIsPausedTimer(!isPausedTimer);
+            setIsPausedTimer(true);
             setIsPausedStopWatch(!isPausedStopWatch);
             setIsUnsavedChangesWarningModalOpen(!isUnsavedChangesWarningModalOpen);
           }}>
@@ -183,7 +181,7 @@ const TestSubmitOrCancle = (props: Props) => {
         </span>
         <button
           onClick={() => {
-            setIsPausedTimer(!isPausedTimer);
+            setIsPausedTimer(true);
             setIsPausedStopWatch(!isPausedStopWatch);
             setIsSubmitConfirmationModalOpen(!isSubmitConfirmationModalOpen);
           }}

--- a/src/components/exam/TimerModal.tsx
+++ b/src/components/exam/TimerModal.tsx
@@ -56,7 +56,7 @@ const TimerModal: React.FC<SessionModalProps> = ({
           </div>
           <button
             onClick={() => {
-              setIsPausedTimer(!isPausedTimer);
+              setIsPausedTimer(false);
               setSelectedMockExamId(mockExamId);
               router.push('/exam/test');
             }}

--- a/src/components/exam/TimerModal.tsx
+++ b/src/components/exam/TimerModal.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/navigation';
 import React, { SVGProps, useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 
-import { mockExamIdState } from '@/recoil/exam/atom';
+import { mockExamIdState, timerIsPaused } from '@/recoil/exam/atom';
 
 interface SessionModalProps {
   mockExamId: number;
@@ -21,6 +21,8 @@ const TimerModal: React.FC<SessionModalProps> = ({
   closeSessionModal,
 }) => {
   const [selectedMockExamId, setSelectedMockExamId] = useRecoilState(mockExamIdState);
+  // 모달창을 띄우면 타이머를 잠시 멈추게 하는 state
+  const [isPausedTimer, setIsPausedTimer] = useRecoilState(timerIsPaused);
   const router = useRouter();
   // 타이머 모달이 나타나면 기존 세션 모달을 종료 위한 동작
   useEffect(() => {
@@ -54,6 +56,7 @@ const TimerModal: React.FC<SessionModalProps> = ({
           </div>
           <button
             onClick={() => {
+              setIsPausedTimer(!isPausedTimer);
               setSelectedMockExamId(mockExamId);
               router.push('/exam/test');
             }}

--- a/src/components/exam/UnsavedChangesWarningModal.tsx
+++ b/src/components/exam/UnsavedChangesWarningModal.tsx
@@ -63,6 +63,7 @@ const UnsavedChangesWarningModal = (props: Props) => {
             </button>
             <button
               onClick={() => {
+                setIsPausedTimer(!isPausedTimer);
                 onMove();
                 //체점 결과 초기화
                 setUserAnswerList([]);

--- a/src/components/exam/UnsavedChangesWarningModal.tsx
+++ b/src/components/exam/UnsavedChangesWarningModal.tsx
@@ -54,7 +54,7 @@ const UnsavedChangesWarningModal = (props: Props) => {
           <div className={'flex justify-end gap-x-2'}>
             <button
               onClick={() => {
-                setIsPausedTimer(!isPausedTimer);
+                setIsPausedTimer(false);
                 setIsPausedStopWatch(!isPausedStopWatch);
                 setIsUnsavedChangesWarningModalOpen(!isUnsavedChangesWarningModalOpen);
               }}
@@ -63,7 +63,7 @@ const UnsavedChangesWarningModal = (props: Props) => {
             </button>
             <button
               onClick={() => {
-                setIsPausedTimer(!isPausedTimer);
+                setIsPausedTimer(true);
                 onMove();
                 //체점 결과 초기화
                 setUserAnswerList([]);

--- a/src/hooks/useCalculateScore.tsx
+++ b/src/hooks/useCalculateScore.tsx
@@ -11,7 +11,6 @@ const useCalculateScore = (mockExamId: number) => {
   const [userAnswerList, setUserAnswerList] = useRecoilState<UserAnswerRequests[]>(userAnswerRequestsList);
   const [subjectResultList, setSubjectResultList] = useRecoilState(subjectResultRequestsList);
   const { questions, isLoading, isError } = useMockExamQuestions(mockExamId);
-
   /**
    * 사용자가 선택한 각 선택지가 맞았는지 틀렸는지 채점
    */
@@ -63,7 +62,6 @@ const useCalculateScore = (mockExamId: number) => {
           newUserAnswerList = [];
         }
       });
-
       setSubjectResultList(newSubjectResultList);
     }
   };

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -252,7 +252,7 @@ export interface ReviewIncorrectAnswersContent {
 }
 
 export interface ReviewIncorrectMockExam {
-  MockExamId: number;
+  mockExamId: number;
   examYear: number;
   round: number;
   timeLimit: number;


### PR DESCRIPTION
Closes #117 
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세
1. 체출버튼을 누르지 않았는데 제출되는 문제가 발생하였습니다.
    - 제출하는 `useEffect`코드에 `subjectResultList`의 값이 채워져 있으면 제출하도록 기존에 코드가 작성되어있었고, 제출 후 `subjectResultList`를 초기화하지 않아 기존의 값이 있는 상태가 유지되어서, 랜더링 될 때마다 제출되는 문제가 발생하였고, 제출하기, 확인 버튼을 클릭할 경우에 `subjectResultList`와 `userAnswerList`를 초기화해주는 작업을 진행했습니다.

2. 초기화를 하지 않아 다시 문제를 풀때 해당 데이터가 그대로 남아있는 문제가 발생하였습니다.
    - 그만두기, 제출하기, 확인 버튼을 클릭시 `subjectResultList`, `userAnswerList`를 `[]`로 초기화하였습니다.

3. 제출되고 다시 문제를 풀면 1번부터 시작해야하는데, 마지막에 머문 번호로 이동됩니다.
    - `userAnswer`, `questionIdx`를 초기화하지 않아서 발생한 문제로 그만두기, 제출하기, 확인버튼을 클릭할 경우에 `userAnswer`, `questionIdx`를 초기화하여 다시 문제를 풀 때 1번 부터 풀 수 있도록 초기화해주었습니다.

4. 타이머가 다시 문제를 풀었을 때 동작되지 않는 문제가 발생하였습니다.
    - 모달창들을 오픈했을 때, 모달창들을 닫을 때는 `setIsPausedTimer(false)` 모달창 제출하기를 눌렀을때, 모달창 확인버튼을 눌렀을 때는 `setIsPausedTimer(true)` 모의고사를 시작할 때는 `setIsPausedTimer(false)` 코드를 추가하여 타이머가 정상작동되도록 수정하였습니다.

5. 결과페이지가 제대로 동작되지 않는 문제가 발생했습니다.
    - 결과페이지는 따로 브랜치를 파서 수정할 예정입니다.

6. 선택된 답듵이 다 0처리되는 문제가 발생했습니다.
    - 2번을 해결하는 과정에서 useEffect의 조건을 설정하지 않아 계속 제출되는 에러가 발생하여 제출하기 버튼을 누를 때, 바로`setUserAnswerList([]);` `setSubjectResultList([]);` 를 해주었는데, 이렇게 설정하니 기존에 클릭했던 정보들이 싹 날라가는 문제가 발생하게 되었었고, 이 코드를 제출하기 버튼을 눌렀을 때 발생시키지 않도록 제거하고 제출 post가 된 다음 그 응답으로 순서를 변경하여 문제를 해결하였습니다.

7. 문제를 이동시킬때 머문시간을 체크하지 않는 문제가 발생하였습니다.
    - `recordSessionTime()` 함수를 `AllQuestionModalProps`로 전달하여 문제 클릭시 머문시간을 기록할 수 있도록 수정하였습니다.

8. 문제를 다시 풀 때` Qustion.tsx`의 `resetOptionOnReclick()`에서 무한루프가 발생하는 문제가 발생하였습니다.
    - 기존 코드에서는` userAnswer.selectOptionSeq === userAnswerList[questionIdx]?.selectOptionSeq`만 같으면 `setUserAnswer`의 `selectOptionSeq`를 0으로 초기화하는 로직이어서, 처음 시작 시 `resetOptionOnReclick` 함수에서 `userAnswer.selectOptionSeq`가 0이고 이 번호가 존재하면 `userAnswerList[questionIdx]?.selectOptionSeq`를 0으로 업데이트 하게 되고, `userAnswer.selectOptionSeq`와 `userAnswerList[questionIdx]?.selectOptionSeq`가 0으로 동일하기 때문에 또, `userAnswer.selectOptionSeq === userAnswerList[questionIdx]?.selectOptionSeq`가 같게 되고 또 0으로 되고 이런 무한루프가 발생하여 무한루프 에러가 발생하였습니다. 따라서 `resetOptionOnReclick` 함수의 원래 의도대로 0이 아닌 똑같은 번호를 다시 클릭하였을 때 0으로 초기화하여 클릭하지 않은 상태로 만드는 함수로 만들기 위해 `userAnswerList[questionIdx]?.selectOptionSeq !== 0 && userAnswer.selectOptionSeq !== 0`의 조건을 추가해주었습니다.

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

## 😭 어려웠던 점

8번 문제가 발생하였을 때, 어떤 부분에서 발생하는지 하나하나 파악하느라 시간이 오래걸렸고, 문제를 정의하고 발견하는 부분에서 논리적 사고가 중요하다는 점을 깨달았습니다.
